### PR TITLE
:boom: refactor(major): refactored dropdown, all interactive groups

### DIFF
--- a/__tests__/compositions/Dropdown/InlineDropdown.test.tsx
+++ b/__tests__/compositions/Dropdown/InlineDropdown.test.tsx
@@ -25,7 +25,7 @@ describe('<InlineDropdown />', () => {
 
     const { getByText } = render(
       <InlineDropdown
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super fantastic label"
         layout="raised"
         onSelect={onSelect}

--- a/__tests__/compositions/Dropdown/ManagedDropdown.test.tsx
+++ b/__tests__/compositions/Dropdown/ManagedDropdown.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { InlineDropdown } from 'lib';
+import { ManagedDropdown } from 'lib';
 
 export const options = [
   { id: 'red', value: 'fancy-red', label: 'Red' },
@@ -19,12 +19,12 @@ export const options = [
   { id: 'violet-red', label: 'Violet red' },
 ];
 
-describe('<InlineDropdown />', () => {
+describe('<ManagedDropdown />', () => {
   it('should render a basic inline dropdown', () => {
     const onSelect = jest.fn();
 
     const { getByText } = render(
-      <InlineDropdown
+      <ManagedDropdown
         initialSelected={[options[3]]}
         label="Super fantastic label"
         layout="raised"

--- a/__tests__/compositions/InteractiveList/InteractiveList.test.tsx
+++ b/__tests__/compositions/InteractiveList/InteractiveList.test.tsx
@@ -22,7 +22,7 @@ const options = [
 describe('<InteractiveList />', () => {
   it('should render a basic interactiveList', () => {
     const { getByText } = render(
-      <InteractiveList initialSelected="red" items={options} variant="bordered">
+      <InteractiveList initialSelected={['red']} items={options} variant="bordered">
         An empty notification
       </InteractiveList>,
     );

--- a/src/components/Form/docs/form.mdx
+++ b/src/components/Form/docs/form.mdx
@@ -9,7 +9,7 @@ import { SearchIcon } from 'icons/SearchIcon';
 import { Button, ButtonGroup } from 'components/Button';
 import { Flex } from 'components/Flex';
 import { Rhythm } from 'components/Rhythm';
-import { InlineDropdown } from 'compositions/Dropdown';
+import { ManagedDropdown } from 'compositions/Dropdown';
 import { StateWrapper } from 'docs/helpers/StateWrapper';
 import { ThemeWrapper } from 'docs/helpers/ThemeWrapper';
 import {
@@ -163,7 +163,7 @@ import { FormDemo } from './helpers/FormDemo';
                 />
               </Rhythm>
               <Rhythm my={2}>
-                <InlineDropdown
+                <ManagedDropdown
                   inputVariant={variant}
                   label="A custom dropdown"
                   layout="raised"

--- a/src/components/InteractiveGroup/InteractiveGroupContext.ts
+++ b/src/components/InteractiveGroup/InteractiveGroupContext.ts
@@ -1,17 +1,19 @@
 import { createContext } from 'react';
+import { InteractiveGroupItemId } from './types';
 import { UseInteractiveGroupResponse } from './useInteractiveGroup';
 
 export type InteractiveGroupContextValue<
+  T extends InteractiveGroupItemId = string,
   E extends HTMLElement = HTMLDivElement,
   I extends HTMLElement = HTMLElement
-> = Omit<UseInteractiveGroupResponse<E, I>, 'ref'>;
+> = Omit<UseInteractiveGroupResponse<T, E, I>, 'ref'>;
 
-export const InteractiveGroupContext = createContext<InteractiveGroupContextValue<any, any>>({
+export const InteractiveGroupContext = createContext<InteractiveGroupContextValue<any, any, any>>({
   focusedIndex: undefined,
   handleItemClick: (/* event, id */) => {},
   isSelected: (/* id */) => false,
-  selectedId: undefined,
+  selectedIds: undefined,
+  selectId: (/* id, [props] */) => {},
   setFocused: (/* id, [props] */) => {},
-  setSelected: (/* id, [props] */) => {},
-  unsetSelected: (/* id, [props] */) => {},
+  unselectId: (/* id, [props] */) => {},
 });

--- a/src/components/InteractiveGroup/InteractiveGroupProvider.tsx
+++ b/src/components/InteractiveGroup/InteractiveGroupProvider.tsx
@@ -1,115 +1,34 @@
-import produce, { Draft } from 'immer';
-import React, { Reducer, useReducer, useRef } from 'react';
-import { InteractiveGroupContext, InteractiveGroupContextValue } from './InteractiveGroupContext';
+import React, { Reducer, useReducer } from 'react';
+import {
+  UnmanagedInteractiveGroupProvider,
+  UnmanagedInteractiveGroupProviderProps,
+} from './UnmanagedInteractiveGroupProvider';
 import { InteractiveGroupStateAction } from './interactiveGroupActions';
 import {
   interactiveGroupReducer,
-  getInteractiveGroupInitialState as getInitialState,
+  getInteractiveGroupInitialState,
   InteractiveGroupState,
 } from './interactiveGroupReducer';
 import { InteractiveGroupItemId } from './types';
-import { useInteractiveGroup, UseInteractiveGroupInterface, UseInteractiveGroupResponse } from './useInteractiveGroup';
 
 export interface InteractiveGroupProviderProps<
   T extends InteractiveGroupItemId = string,
   E extends HTMLElement = HTMLDivElement,
   I extends HTMLElement = HTMLElement
-> extends Omit<React.HTMLAttributes<E>, 'onKeyDown' | 'onSelect'>,
-    Omit<UseInteractiveGroupInterface<T>, 'reducer'> {
-  children:
-    | React.ReactElement
-    | ((ref: UseInteractiveGroupResponse<T, E, I>['ref'], props: unknown) => React.ReactElement<E>)
-    | null;
-}
+> extends Omit<UnmanagedInteractiveGroupProviderProps<T, E, I>, 'reducer'> {}
 
-/**
- * - T is the type of IDs allowed
- * - E is the type of the element that the returned ref gets attached to
- * - I is the type of item element
- */
+/** The interactive group provider is a managed wrapper around the unmanaged interactive group provider */
 export function InteractiveGroupProvider<
   T extends InteractiveGroupItemId = string,
   E extends HTMLElement = HTMLDivElement,
   I extends HTMLElement = HTMLElement
->({
-  allowReselect,
-  children,
-  disabled,
-  initialSelected,
-  items,
-  maxSelect,
-  minSelect,
-  onItemClick,
-  onItemFocus,
-  onKeyDown,
-  onSelect,
-  onUnselect,
-  parentRef,
-  selectOnFocus,
-  triggerLinks,
-  ...props
-}: InteractiveGroupProviderProps<T, E, I>): React.ReactElement {
-  const previousValue = useRef<Omit<UseInteractiveGroupResponse<T, E, I>, 'ref'>>(
-    {} as UseInteractiveGroupResponse<T, E, I>,
-  );
-
+>({ initialSelected, items, ...props }: InteractiveGroupProviderProps<T, E, I>): React.ReactElement {
   const reducer = useReducer<Reducer<InteractiveGroupState<T>, InteractiveGroupStateAction<T>>>(
     interactiveGroupReducer,
-    getInitialState({ items, selectedIds: initialSelected }),
+    getInteractiveGroupInitialState({ items, selectedIds: initialSelected }),
   );
 
-  const {
-    focusedIndex,
-    handleItemClick,
-    isSelected,
-    ref,
-    selectedIds,
-    selectId,
-    setFocused,
-    unselectId,
-  } = useInteractiveGroup<T, E, I>({
-    allowReselect,
-    disabled,
-    items,
-    maxSelect,
-    minSelect,
-    onItemClick,
-    onItemFocus,
-    onKeyDown,
-    onSelect,
-    onUnselect,
-    parentRef,
-    reducer,
-    selectOnFocus,
-    triggerLinks,
-  });
-
-  const value = produce<InteractiveGroupContextValue<T, E, I>, Draft<InteractiveGroupContextValue<T, E, I>>>(
-    previousValue.current,
-    draftState => {
-      draftState.focusedIndex = focusedIndex;
-      draftState.handleItemClick = handleItemClick;
-      draftState.isSelected = isSelected;
-      // @ts-ignore [TODO:ts] WTF
-      draftState.selectedIds = selectedIds;
-      draftState.selectId = selectId;
-      draftState.setFocused = setFocused;
-      draftState.unselectId = unselectId;
-    },
-  );
-  previousValue.current = value;
-
-  return (
-    <InteractiveGroupContext.Provider value={value}>
-      {typeof children === 'function' ? (
-        children(ref, props)
-      ) : (
-        <div ref={ref as React.Ref<HTMLDivElement>} {...(props as React.HTMLAttributes<HTMLDivElement>)}>
-          {children}
-        </div>
-      )}
-    </InteractiveGroupContext.Provider>
-  );
+  return <UnmanagedInteractiveGroupProvider<T, E, I> items={items} reducer={reducer} {...props} />;
 }
 
 InteractiveGroupProvider.displayName = 'InteractiveGroupProvider';

--- a/src/components/InteractiveGroup/UnmanagedInteractiveGroupProvider.tsx
+++ b/src/components/InteractiveGroup/UnmanagedInteractiveGroupProvider.tsx
@@ -29,8 +29,6 @@ export function UnmanagedInteractiveGroupProvider<
   allowReselect,
   children,
   disabled,
-  initialSelected,
-  items,
   maxSelect,
   minSelect,
   onItemClick,
@@ -60,7 +58,6 @@ export function UnmanagedInteractiveGroupProvider<
   } = useInteractiveGroup<T, E, I>({
     allowReselect,
     disabled,
-    items,
     maxSelect,
     minSelect,
     onItemClick,

--- a/src/components/InteractiveGroup/UnmanagedInteractiveGroupProvider.tsx
+++ b/src/components/InteractiveGroup/UnmanagedInteractiveGroupProvider.tsx
@@ -1,0 +1,105 @@
+import produce, { Draft } from 'immer';
+import React, { useRef } from 'react';
+import { InteractiveGroupContext, InteractiveGroupContextValue } from './InteractiveGroupContext';
+import { InteractiveGroupItemId } from './types';
+import { useInteractiveGroup, UseInteractiveGroupInterface, UseInteractiveGroupResponse } from './useInteractiveGroup';
+
+export interface UnmanagedInteractiveGroupProviderProps<
+  T extends InteractiveGroupItemId = string,
+  E extends HTMLElement = HTMLDivElement,
+  I extends HTMLElement = HTMLElement
+> extends Omit<React.HTMLAttributes<E>, 'onKeyDown' | 'onSelect'>,
+    UseInteractiveGroupInterface<T> {
+  children:
+    | React.ReactElement
+    | ((ref: UseInteractiveGroupResponse<T, E, I>['ref'], props: unknown) => React.ReactElement<E>)
+    | null;
+}
+
+/**
+ * - T is the type of IDs allowed
+ * - E is the type of the element that the returned ref gets attached to
+ * - I is the type of item element
+ */
+export function UnmanagedInteractiveGroupProvider<
+  T extends InteractiveGroupItemId = string,
+  E extends HTMLElement = HTMLDivElement,
+  I extends HTMLElement = HTMLElement
+>({
+  allowReselect,
+  children,
+  disabled,
+  initialSelected,
+  items,
+  maxSelect,
+  minSelect,
+  onItemClick,
+  onItemFocus,
+  onKeyDown,
+  onSelect,
+  onUnselect,
+  parentRef,
+  reducer,
+  selectOnFocus,
+  triggerLinks,
+  ...props
+}: UnmanagedInteractiveGroupProviderProps<T, E, I>): React.ReactElement {
+  const previousValue = useRef<Omit<UseInteractiveGroupResponse<T, E, I>, 'ref'>>(
+    {} as UseInteractiveGroupResponse<T, E, I>,
+  );
+
+  const {
+    focusedIndex,
+    handleItemClick,
+    isSelected,
+    ref,
+    selectedIds,
+    selectId,
+    setFocused,
+    unselectId,
+  } = useInteractiveGroup<T, E, I>({
+    allowReselect,
+    disabled,
+    items,
+    maxSelect,
+    minSelect,
+    onItemClick,
+    onItemFocus,
+    onKeyDown,
+    onSelect,
+    onUnselect,
+    parentRef,
+    reducer,
+    selectOnFocus,
+    triggerLinks,
+  });
+
+  const value = produce<InteractiveGroupContextValue<T, E, I>, Draft<InteractiveGroupContextValue<T, E, I>>>(
+    previousValue.current,
+    draftState => {
+      draftState.focusedIndex = focusedIndex;
+      draftState.handleItemClick = handleItemClick;
+      draftState.isSelected = isSelected;
+      // @ts-ignore [TODO:ts] WTF
+      draftState.selectedIds = selectedIds;
+      draftState.selectId = selectId;
+      draftState.setFocused = setFocused;
+      draftState.unselectId = unselectId;
+    },
+  );
+  previousValue.current = value;
+
+  return (
+    <InteractiveGroupContext.Provider value={value}>
+      {typeof children === 'function' ? (
+        children(ref, props)
+      ) : (
+        <div ref={ref as React.Ref<HTMLDivElement>} {...(props as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      )}
+    </InteractiveGroupContext.Provider>
+  );
+}
+
+UnmanagedInteractiveGroupProvider.displayName = 'UnmanagedInteractiveGroupProvider';

--- a/src/components/InteractiveGroup/generateInteractiveGroupActions.ts
+++ b/src/components/InteractiveGroup/generateInteractiveGroupActions.ts
@@ -6,20 +6,20 @@ import {
 import { InteractiveGroupItemId, InteractiveGroupItemType } from './types';
 
 export type GeneratedInteractiveGroupActions<T extends InteractiveGroupItemId = string> = {
-  focusFirst: (props: InteractiveGroupEventTypes) => void;
-  focusLast: (props: InteractiveGroupEventTypes) => void;
-  focusNext: (props: InteractiveGroupEventTypes) => void;
-  focusPrevious: (props: InteractiveGroupEventTypes) => void;
-  selectFirst: (props: InteractiveGroupEventTypes) => void;
-  selectFocused: (props: InteractiveGroupEventTypes) => void;
+  focusFirst: (props?: InteractiveGroupEventTypes) => void;
+  focusLast: (props?: InteractiveGroupEventTypes) => void;
+  focusNext: (props?: InteractiveGroupEventTypes) => void;
+  focusPrevious: (props?: InteractiveGroupEventTypes) => void;
+  selectFirst: (props?: InteractiveGroupEventTypes) => void;
+  selectFocused: (props?: InteractiveGroupEventTypes) => void;
   selectId: (id: T, props?: InteractiveGroupEventTypes) => void;
-  selectLast: (props: InteractiveGroupEventTypes) => void;
-  selectNext: (props: InteractiveGroupEventTypes) => void;
-  selectPrevious: (props: InteractiveGroupEventTypes) => void;
-  setFocusedByIndex: (index: number | undefined, props: InteractiveGroupEventTypes) => void;
+  selectLast: (props?: InteractiveGroupEventTypes) => void;
+  selectNext: (props?: InteractiveGroupEventTypes) => void;
+  selectPrevious: (props?: InteractiveGroupEventTypes) => void;
+  setFocusedByIndex: (index: number | undefined, props?: InteractiveGroupEventTypes) => void;
   setItems: (items: InteractiveGroupItemType<T>[]) => void;
   toggleSelected: (id: T, props?: InteractiveGroupEventTypes) => void;
-  toggleSelectedFocused: (props: InteractiveGroupEventTypes) => void;
+  toggleSelectedFocused: (props?: InteractiveGroupEventTypes) => void;
   unselectId: (id: T, props?: InteractiveGroupEventTypes) => void;
 };
 
@@ -74,7 +74,7 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.TOGGLE_SELECTED,
       }),
 
-    selectFocused: ({ event }) =>
+    selectFocused: ({ event } = {}) =>
       dispatch({
         event,
         maxSelect,
@@ -82,7 +82,7 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.SELECT_FOCUSED,
       }),
 
-    toggleSelectedFocused: ({ event }) =>
+    toggleSelectedFocused: ({ event } = {}) =>
       dispatch({
         allowReselect,
         event,
@@ -92,7 +92,7 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.TOGGLE_SELECTED_FOCUSED,
       }),
 
-    selectPrevious: ({ event }) =>
+    selectPrevious: ({ event } = {}) =>
       dispatch({
         maxSelect,
         event,
@@ -100,14 +100,14 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.SELECT_PREVIOUS,
       }),
 
-    focusPrevious: ({ event }) =>
+    focusPrevious: ({ event } = {}) =>
       dispatch({
         event,
         timestamp: Date.now(),
         type: ACTIONS.FOCUS_PREVIOUS,
       }),
 
-    selectNext: ({ event }) =>
+    selectNext: ({ event } = {}) =>
       dispatch({
         event,
         maxSelect,
@@ -115,14 +115,14 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.SELECT_NEXT,
       }),
 
-    focusNext: ({ event }) =>
+    focusNext: ({ event } = {}) =>
       dispatch({
         event,
         timestamp: Date.now(),
         type: ACTIONS.FOCUS_NEXT,
       }),
 
-    selectFirst: ({ event }) =>
+    selectFirst: ({ event } = {}) =>
       dispatch({
         event,
         maxSelect,
@@ -130,14 +130,14 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.SELECT_FIRST,
       }),
 
-    focusFirst: ({ event }) =>
+    focusFirst: ({ event } = {}) =>
       dispatch({
         event,
         timestamp: Date.now(),
         type: ACTIONS.FOCUS_FIRST,
       }),
 
-    selectLast: ({ event }) =>
+    selectLast: ({ event } = {}) =>
       dispatch({
         event,
         maxSelect,
@@ -145,7 +145,7 @@ export function generateInteractiveGroupActions<T extends InteractiveGroupItemId
         type: ACTIONS.SELECT_LAST,
       }),
 
-    focusLast: ({ event }) =>
+    focusLast: ({ event } = {}) =>
       dispatch({
         event,
         timestamp: Date.now(),

--- a/src/components/InteractiveGroup/generateInteractiveGroupActions.ts
+++ b/src/components/InteractiveGroup/generateInteractiveGroupActions.ts
@@ -3,32 +3,32 @@ import {
   InteractiveGroupStateAction,
   InteractiveGroupEventTypes,
 } from './interactiveGroupActions';
-import { InteractiveGroupItemType } from './types';
+import { InteractiveGroupItemId, InteractiveGroupItemType } from './types';
 
-export type GeneratedInteractiveGroupActions = {
-  setItems: (items: InteractiveGroupItemType[]) => void;
-  setFocusedByIndex: (index: number | undefined, props: InteractiveGroupEventTypes) => void;
-  setSelected: (id: string, props?: InteractiveGroupEventTypes) => void;
-  unsetSelected: (id: string, props?: InteractiveGroupEventTypes) => void;
-  toggleSelected: (id: string, props?: InteractiveGroupEventTypes) => void;
-  selectFocused: (props: InteractiveGroupEventTypes) => void;
-  toggleSelectedFocused: (props: InteractiveGroupEventTypes) => void;
-  selectPrevious: (props: InteractiveGroupEventTypes) => void;
-  focusPrevious: (props: InteractiveGroupEventTypes) => void;
-  selectNext: (props: InteractiveGroupEventTypes) => void;
-  focusNext: (props: InteractiveGroupEventTypes) => void;
-  selectFirst: (props: InteractiveGroupEventTypes) => void;
+export type GeneratedInteractiveGroupActions<T extends InteractiveGroupItemId = string> = {
   focusFirst: (props: InteractiveGroupEventTypes) => void;
-  selectLast: (props: InteractiveGroupEventTypes) => void;
   focusLast: (props: InteractiveGroupEventTypes) => void;
+  focusNext: (props: InteractiveGroupEventTypes) => void;
+  focusPrevious: (props: InteractiveGroupEventTypes) => void;
+  selectFirst: (props: InteractiveGroupEventTypes) => void;
+  selectFocused: (props: InteractiveGroupEventTypes) => void;
+  selectId: (id: T, props?: InteractiveGroupEventTypes) => void;
+  selectLast: (props: InteractiveGroupEventTypes) => void;
+  selectNext: (props: InteractiveGroupEventTypes) => void;
+  selectPrevious: (props: InteractiveGroupEventTypes) => void;
+  setFocusedByIndex: (index: number | undefined, props: InteractiveGroupEventTypes) => void;
+  setItems: (items: InteractiveGroupItemType<T>[]) => void;
+  toggleSelected: (id: T, props?: InteractiveGroupEventTypes) => void;
+  toggleSelectedFocused: (props: InteractiveGroupEventTypes) => void;
+  unselectId: (id: T, props?: InteractiveGroupEventTypes) => void;
 };
 
-export function generateInteractiveGroupActions(
-  dispatch: React.Dispatch<InteractiveGroupStateAction>,
-  disableUnselect?: boolean,
-  allowMultiSelect?: boolean,
+export function generateInteractiveGroupActions<T extends InteractiveGroupItemId = string>(
+  dispatch: React.Dispatch<InteractiveGroupStateAction<T>>,
+  minSelect: number,
+  maxSelect: number,
   allowReselect?: boolean,
-): GeneratedInteractiveGroupActions {
+): GeneratedInteractiveGroupActions<T> {
   return {
     setItems: items =>
       dispatch({
@@ -45,58 +45,56 @@ export function generateInteractiveGroupActions(
         type: ACTIONS.SET_FOCUSED,
       }),
 
-    setSelected: (id, { event } = {}) =>
+    selectId: (id, { event } = {}) =>
       dispatch({
-        allowMultiSelect,
         event,
-        selectedId: id,
+        id,
+        maxSelect,
         timestamp: Date.now(),
-        type: ACTIONS.SET_SELECTED,
+        type: ACTIONS.SELECT_ID,
       }),
 
-    unsetSelected: (id, { event } = {}) =>
+    unselectId: (id, { event } = {}) =>
       dispatch({
-        allowMultiSelect,
-        disableUnselect,
         event,
-        selectedId: id,
+        id,
+        minSelect,
         timestamp: Date.now(),
-        type: ACTIONS.UNSET_SELECTED,
+        type: ACTIONS.UNSELECT_ID,
       }),
 
     toggleSelected: (id, { event } = {}) =>
       dispatch({
-        allowMultiSelect,
         allowReselect,
-        disableUnselect,
         event,
-        selectedId: id,
+        id,
+        minSelect,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.TOGGLE_SELECTED,
       }),
 
     selectFocused: ({ event }) =>
       dispatch({
-        allowMultiSelect,
-        disableUnselect,
         event,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.SELECT_FOCUSED,
       }),
 
     toggleSelectedFocused: ({ event }) =>
       dispatch({
-        allowMultiSelect,
         allowReselect,
-        disableUnselect,
         event,
+        minSelect,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.TOGGLE_SELECTED_FOCUSED,
       }),
 
     selectPrevious: ({ event }) =>
       dispatch({
-        allowMultiSelect,
+        maxSelect,
         event,
         timestamp: Date.now(),
         type: ACTIONS.SELECT_PREVIOUS,
@@ -111,8 +109,8 @@ export function generateInteractiveGroupActions(
 
     selectNext: ({ event }) =>
       dispatch({
-        allowMultiSelect,
         event,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.SELECT_NEXT,
       }),
@@ -126,8 +124,8 @@ export function generateInteractiveGroupActions(
 
     selectFirst: ({ event }) =>
       dispatch({
-        allowMultiSelect,
         event,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.SELECT_FIRST,
       }),
@@ -141,8 +139,8 @@ export function generateInteractiveGroupActions(
 
     selectLast: ({ event }) =>
       dispatch({
-        allowMultiSelect,
         event,
+        maxSelect,
         timestamp: Date.now(),
         type: ACTIONS.SELECT_LAST,
       }),

--- a/src/components/InteractiveGroup/index.ts
+++ b/src/components/InteractiveGroup/index.ts
@@ -10,3 +10,4 @@ export * from './useInteractiveGroup';
 export * from './useInteractiveGroupItem';
 export * from './interactiveGroupSelector';
 export * from './types';
+export * from './UnmanagedInteractiveGroupProvider';

--- a/src/components/InteractiveGroup/interactiveGroupActions.ts
+++ b/src/components/InteractiveGroup/interactiveGroupActions.ts
@@ -1,4 +1,4 @@
-import { InteractiveGroupItemType } from './types';
+import { InteractiveGroupItemType, InteractiveGroupItemId } from './types';
 
 export enum interactiveGroupActions {
   CLEAR = 'CLEAR',
@@ -9,15 +9,15 @@ export enum interactiveGroupActions {
   RESET = 'RESET',
   SELECT_FIRST = 'SELECT_FIRST',
   SELECT_FOCUSED = 'SELECT_FOCUSED',
+  SELECT_ID = 'SELECT_ID',
   SELECT_LAST = 'SELECT_LAST',
   SELECT_NEXT = 'SELECT_NEXT',
   SELECT_PREVIOUS = 'SELECT_PREVIOUS',
   SET_FOCUSED = 'SET_FOCUSED',
   SET_ITEMS = 'SET_ITEMS',
-  SET_SELECTED = 'SET_SELECTED',
-  TOGGLE_SELECTED_FOCUSED = 'TOGGLE_SELECTED_FOCUSED',
   TOGGLE_SELECTED = 'TOGGLE_SELECTED',
-  UNSET_SELECTED = 'UNSET_SELECTED',
+  TOGGLE_SELECTED_FOCUSED = 'TOGGLE_SELECTED_FOCUSED',
+  UNSELECT_ID = 'UNSELECT_ID',
 }
 
 export type InteractiveGroupEventTypes = { event?: React.SyntheticEvent | KeyboardEvent };
@@ -27,7 +27,7 @@ export type InteractiveGroupStateActionClear = InteractiveGroupEventTypes & {
   type: interactiveGroupActions.CLEAR;
 };
 
-export type InteractiveGroupStateActionFocus = InteractiveGroupEventTypes & {
+export type InteractiveGroupStateActionFocusSequential = InteractiveGroupEventTypes & {
   timestamp: number;
   type:
     | interactiveGroupActions.FOCUS_FIRST
@@ -40,8 +40,8 @@ export type InteractiveGroupStateActionReset = {
   type: interactiveGroupActions.RESET;
 };
 
-export type InteractiveGroupStateActionSelect = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
+export type InteractiveGroupStateActionSelectSequential = InteractiveGroupEventTypes & {
+  maxSelect: number;
   timestamp: number;
   type:
     | interactiveGroupActions.SELECT_FIRST
@@ -51,9 +51,8 @@ export type InteractiveGroupStateActionSelect = InteractiveGroupEventTypes & {
 };
 
 export type InteractiveGroupStateActionSelectFocused = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
   allowReselect?: boolean;
-  disableUnselect?: boolean;
+  maxSelect: number;
   timestamp: number;
   type: interactiveGroupActions.SELECT_FOCUSED;
 };
@@ -64,54 +63,59 @@ export type InteractiveGroupStateActionSetFocused = InteractiveGroupEventTypes &
   type: interactiveGroupActions.SET_FOCUSED;
 };
 
-export type InteractiveGroupStateActionSetItems = {
-  items: InteractiveGroupItemType[];
+export type InteractiveGroupStateActionSetItems<T extends InteractiveGroupItemId = string> = {
+  items: InteractiveGroupItemType<T>[];
   timestamp: number;
   type: interactiveGroupActions.SET_ITEMS;
 };
 
-export type InteractiveGroupStateActionSetSelected = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
+export type InteractiveGroupStateActionSelectId<
+  T extends InteractiveGroupItemId = string
+> = InteractiveGroupEventTypes & {
   allowReselect?: boolean;
-  selectedId: string;
+  id: T;
+  maxSelect: number;
   timestamp: number;
-  type: interactiveGroupActions.SET_SELECTED;
+  type: interactiveGroupActions.SELECT_ID;
 };
 
 export type InteractiveGroupStateActionToggleSelectedFocused = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
   allowReselect?: boolean;
-  disableUnselect?: boolean;
+  maxSelect: number;
+  minSelect: number;
   timestamp: number;
   type: interactiveGroupActions.TOGGLE_SELECTED_FOCUSED;
 };
 
-export type InteractiveGroupStateActionToggleSelected = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
+export type InteractiveGroupStateActionToggleSelected<
+  T extends InteractiveGroupItemId = string
+> = InteractiveGroupEventTypes & {
   allowReselect?: boolean;
-  disableUnselect?: boolean;
-  selectedId: string;
+  id: T;
+  maxSelect: number;
+  minSelect: number;
   timestamp: number;
   type: interactiveGroupActions.TOGGLE_SELECTED;
 };
 
-export type InteractiveGroupStateActionUnsetSelected = InteractiveGroupEventTypes & {
-  allowMultiSelect?: boolean;
-  disableUnselect?: boolean;
-  selectedId: string;
+export type InteractiveGroupStateActionUnselectId<
+  T extends InteractiveGroupItemId = string
+> = InteractiveGroupEventTypes & {
+  id: T;
+  minSelect: number;
   timestamp: number;
-  type: interactiveGroupActions.UNSET_SELECTED;
+  type: interactiveGroupActions.UNSELECT_ID;
 };
 
-export type InteractiveGroupStateAction =
+export type InteractiveGroupStateAction<T extends InteractiveGroupItemId = string> =
   | InteractiveGroupStateActionClear
-  | InteractiveGroupStateActionFocus
+  | InteractiveGroupStateActionFocusSequential
   | InteractiveGroupStateActionReset
-  | InteractiveGroupStateActionSelect
+  | InteractiveGroupStateActionSelectSequential
   | InteractiveGroupStateActionSelectFocused
   | InteractiveGroupStateActionSetFocused
-  | InteractiveGroupStateActionSetItems
-  | InteractiveGroupStateActionSetSelected
+  | InteractiveGroupStateActionSetItems<T>
+  | InteractiveGroupStateActionSelectId<T>
   | InteractiveGroupStateActionToggleSelectedFocused
-  | InteractiveGroupStateActionToggleSelected
-  | InteractiveGroupStateActionUnsetSelected;
+  | InteractiveGroupStateActionToggleSelected<T>
+  | InteractiveGroupStateActionUnselectId<T>;

--- a/src/components/InteractiveGroup/interactiveGroupItemsFactory.ts
+++ b/src/components/InteractiveGroup/interactiveGroupItemsFactory.ts
@@ -7,6 +7,10 @@ export class InteractiveGroupItems<T extends InteractiveGroupItemId = string> {
     this.items = items;
   }
 
+  public getAll(): InteractiveGroupItemType<T>[] {
+    return this.items;
+  }
+
   public getItemId(item: InteractiveGroupItemType<T>): T {
     return item.id;
   }

--- a/src/components/InteractiveGroup/interactiveGroupItemsFactory.ts
+++ b/src/components/InteractiveGroup/interactiveGroupItemsFactory.ts
@@ -1,41 +1,43 @@
-import { InteractiveGroupItemType } from './types';
+import { InteractiveGroupItemId, InteractiveGroupItemType } from './types';
 
-export class InteractiveGroupItems {
-  items: InteractiveGroupItemType[];
+export class InteractiveGroupItems<T extends InteractiveGroupItemId = string> {
+  items: InteractiveGroupItemType<T>[];
 
-  constructor(items: InteractiveGroupItemType[] = []) {
+  constructor(items: InteractiveGroupItemType<T>[] = []) {
     this.items = items;
   }
 
-  public getItemId(item: InteractiveGroupItemType): string {
+  public getItemId(item: InteractiveGroupItemType<T>): T {
     return item.id;
   }
 
-  public isItemDisabled(item: InteractiveGroupItemType): boolean {
+  public isItemDisabled(item: InteractiveGroupItemType<T>): boolean {
     return !!item.disabled;
   }
 
-  public isItemTriggerOnly(item: InteractiveGroupItemType): boolean {
+  public isItemTriggerOnly(item: InteractiveGroupItemType<T>): boolean {
     return !item || !!item.triggerOnly;
   }
 
-  public getIndexById(id?: string): number | undefined {
+  public getIndexById(id?: T): number | undefined {
     const index = this.items.findIndex(item => this.getItemId(item) === id);
     return index === -1 ? undefined : index;
   }
 
-  public getIndexByIds(ids: Array<string | undefined>): number[] | undefined {
+  public getIndexByIds(ids: T[]): number[] | undefined {
     const indexes = ids?.map(id => this.getIndexById(id)).filter(index => index !== undefined) as number[];
     return indexes?.length > 0 ? indexes : undefined;
   }
 
-  public getItemById(id?: string): InteractiveGroupItemType | undefined {
+  public getItemById(id?: T): InteractiveGroupItemType<T> | undefined {
     const index = id ? this.getIndexById(id) : undefined;
     return index !== undefined ? this.items[index as number] : undefined;
   }
 
-  public getItemByIds(ids: Array<string | undefined>): InteractiveGroupItemType[] | undefined {
-    const items = ids?.map(id => this.getItemById(id)).filter(item => item !== undefined) as InteractiveGroupItemType[];
+  public getItemByIds(ids: T[]): InteractiveGroupItemType<T>[] | undefined {
+    const items = ids
+      ?.map(id => this.getItemById(id))
+      .filter(item => item !== undefined) as InteractiveGroupItemType<T>[];
     return items?.length > 0 ? items : undefined;
   }
 
@@ -63,7 +65,7 @@ export class InteractiveGroupItems {
     return undefined;
   }
 
-  at(index: number): InteractiveGroupItemType {
+  at(index: number): InteractiveGroupItemType<T> {
     return this.items[index];
   }
 
@@ -84,4 +86,6 @@ export class InteractiveGroupItems {
   }
 }
 
-export const interactiveGroupItemsFactory = (items: InteractiveGroupItemType[]) => new InteractiveGroupItems(items);
+export const interactiveGroupItemsFactory = <T extends InteractiveGroupItemId = string>(
+  items: InteractiveGroupItemType<T>[],
+) => new InteractiveGroupItems<T>(items);

--- a/src/components/InteractiveGroup/interactiveGroupSelector.ts
+++ b/src/components/InteractiveGroup/interactiveGroupSelector.ts
@@ -1,33 +1,54 @@
 import { InteractiveGroupState } from './interactiveGroupReducer';
+import { InteractiveGroupItemId } from './types';
 
-export const selectItems = (state: InteractiveGroupState) => state.items;
-export const selectEvents = (state: InteractiveGroupState) => state.events;
-export const selectTimes = (state: InteractiveGroupState) => state.times;
-export const selectFocusedIndex = (state: InteractiveGroupState) => state.focusedIndex;
-export const selectSelectedId = (state: InteractiveGroupState) => state.selectedId;
-export const selectTriggeredId = (state: InteractiveGroupState) => state.triggeredId;
+export const selectItems = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) => state.items;
 
-export const selectFocusedItem = (state: InteractiveGroupState) =>
-  selectItems(state).at(selectFocusedIndex(state) || -1);
+export const selectEvents = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  state.events;
 
-export const selectSelectedItem = (state: InteractiveGroupState) => {
-  const selectedId = selectSelectedId(state);
-  return Array.isArray(selectedId)
-    ? selectItems(state).getItemByIds(selectedId)
-    : selectItems(state).getItemById(selectedId);
-};
+export const selectTimes = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) => state.times;
 
-export const selectTriggeredItem = (state: InteractiveGroupState) =>
-  selectItems(state).getItemById(selectTriggeredId(state));
+export const selectFocusedIndex = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  state.focusedIndex;
 
-export const selectFocusedEvent = (state: InteractiveGroupState) => selectEvents(state).focused;
-export const selectSelectedEvent = (state: InteractiveGroupState) => selectEvents(state).selected;
-export const selectUnselectedEvent = (state: InteractiveGroupState) => selectEvents(state).unselected;
-export const selectTriggeredEvent = (state: InteractiveGroupState) => selectEvents(state).triggered;
-export const selectClearedEvent = (state: InteractiveGroupState) => selectEvents(state).cleared;
+export const selectSelectedIds = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  state.selectedIds;
 
-export const selectFocusedTime = (state: InteractiveGroupState) => selectTimes(state).focused;
-export const selectSelectedTime = (state: InteractiveGroupState) => selectTimes(state).selected;
-export const selectUnselectedTime = (state: InteractiveGroupState) => selectTimes(state).unselected;
-export const selectTriggeredTime = (state: InteractiveGroupState) => selectTimes(state).triggered;
-export const selectClearedTime = (state: InteractiveGroupState) => selectTimes(state).cleared;
+export const selectTriggeredId = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  state.triggeredId;
+
+export const selectFocusedItem = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectItems<T>(state).at(selectFocusedIndex(state) || -1);
+
+export const selectTriggeredItem = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectItems<T>(state).getItemById(selectTriggeredId<T>(state));
+
+export const selectFocusedEvent = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectEvents<T>(state).focused;
+
+export const selectSelectedEvent = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectEvents<T>(state).selected;
+
+export const selectUnselectedEvent = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectEvents<T>(state).unselected;
+
+export const selectTriggeredEvent = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectEvents<T>(state).triggered;
+
+export const selectClearedEvent = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectEvents<T>(state).cleared;
+
+export const selectFocusedTime = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectTimes<T>(state).focused;
+
+export const selectSelectedTime = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectTimes<T>(state).selected;
+
+export const selectUnselectedTime = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectTimes<T>(state).unselected;
+
+export const selectTriggeredTime = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectTimes<T>(state).triggered;
+
+export const selectClearedTime = <T extends InteractiveGroupItemId = string>(state: InteractiveGroupState<T>) =>
+  selectTimes<T>(state).cleared;

--- a/src/components/InteractiveGroup/types.ts
+++ b/src/components/InteractiveGroup/types.ts
@@ -1,6 +1,8 @@
-export type InteractiveGroupItemType = {
+export type InteractiveGroupItemId = string | number;
+
+export type InteractiveGroupItemType<T extends InteractiveGroupItemId> = {
   disabled?: boolean;
-  id: string;
+  id: T;
   label: React.ReactNode;
   triggerOnly?: () => void;
 };

--- a/src/components/InteractiveGroup/useInteractiveGroup.ts
+++ b/src/components/InteractiveGroup/useInteractiveGroup.ts
@@ -14,15 +14,13 @@ import {
   selectTriggeredId,
   selectSelectedIds,
 } from './interactiveGroupSelector';
-import { InteractiveGroupItemId, InteractiveGroupItemType } from './types';
+import { InteractiveGroupItemId } from './types';
 
 export interface UseInteractiveGroupInterface<T extends InteractiveGroupItemId = string> {
   /* This will allow an already selected item to be re-triggered */
   allowReselect?: boolean;
   /* This disables interaction across the whole group */
   disabled?: boolean;
-  initialSelected?: T[];
-  items: InteractiveGroupItemType<T>[];
   /** Set minSelect to 0 to allow unselecting the current item */
   minSelect?: number;
   /** Set maxSelect to -1 to allow an unlimited amount */
@@ -30,7 +28,7 @@ export interface UseInteractiveGroupInterface<T extends InteractiveGroupItemId =
   onItemClick?: (event: React.MouseEvent | React.TouchEvent, id: T) => void;
   onItemFocus?: (event: InteractiveGroupEventTypes['event'] | undefined, props: { id: T; index: number }) => void;
   onKeyDown?: (event: KeyboardEvent, props?: { used?: boolean }) => void;
-  onSelect?: (event: InteractiveGroupEventTypes['event'], props: { id?: T; index?: number }, selected?: T[]) => void;
+  onSelect?: (event: InteractiveGroupEventTypes['event'], props: { id?: T; index?: number }, selected: T[]) => void;
   onSelectionChange?: (event: InteractiveGroupEventTypes['event'], selection: T[]) => void;
   onUnselect?: (event: InteractiveGroupEventTypes['event'], props: { id?: T; index?: number }, selected?: T[]) => void;
   parentRef?: React.RefObject<HTMLElement>;
@@ -68,7 +66,6 @@ export function useInteractiveGroup<
 >({
   allowReselect,
   disabled,
-  items: initialItems,
   minSelect = 1,
   maxSelect = 1,
   onItemClick,
@@ -103,7 +100,6 @@ export function useInteractiveGroup<
     selectNext,
     selectPrevious,
     setFocusedByIndex,
-    setItems,
     toggleSelected,
     toggleSelectedFocused,
     unselectId,
@@ -126,11 +122,6 @@ export function useInteractiveGroup<
 
   const isSelected: UseInteractiveGroupResponse<T, E, I>['isSelected'] = id =>
     !!(Array.isArray(state.selectedIds) && state.selectedIds.includes(id));
-
-  // update the state if the items change
-  useEffect(() => {
-    setItems(initialItems);
-  }, [initialItems, setItems]);
 
   // call the onItemFocus callback if the focus changes
   useEffect(() => {

--- a/src/components/InteractiveGroup/useInteractiveGroup.ts
+++ b/src/components/InteractiveGroup/useInteractiveGroup.ts
@@ -19,6 +19,8 @@ import {
 } from './interactiveGroupSelector';
 import { InteractiveGroupItemType } from './types';
 
+export type InteractiveGroupSelectedId = string | string[];
+
 export interface UseInteractiveGroupInterface {
   allowMultiSelect?: boolean;
   /* This will allow an already selected item to be re-triggered */
@@ -31,8 +33,16 @@ export interface UseInteractiveGroupInterface {
   onItemClick?: (event: React.MouseEvent | React.TouchEvent, id: string) => void;
   onItemFocus?: (event: InteractiveGroupEventTypes['event'] | undefined, props: { id: string; index: number }) => void;
   onKeyDown?: (event: KeyboardEvent, props?: { used?: boolean }) => void;
-  onSelect?: (event: InteractiveGroupEventTypes['event'], props: { id?: string; index?: number }) => void;
-  onUnselect?: (event: InteractiveGroupEventTypes['event'], props: { id?: string }) => void;
+  onSelect?: (
+    event: InteractiveGroupEventTypes['event'],
+    props: { id?: string; index?: number },
+    selected?: InteractiveGroupSelectedId,
+  ) => void;
+  onUnselect?: (
+    event: InteractiveGroupEventTypes['event'],
+    props: { id?: string; index?: number },
+    selected?: InteractiveGroupSelectedId,
+  ) => void;
   parentRef?: React.RefObject<HTMLElement>;
   selectOnFocus?: boolean;
   /** If this is set and an item contains a link, when the item is selected that link will be triggered */
@@ -44,7 +54,7 @@ export type UseInteractiveGroupResponse<E extends HTMLElement = HTMLDivElement, 
   handleItemClick: (event: React.MouseEvent<I> | React.TouchEvent<I>, id: string) => void;
   ref: React.Ref<E>;
   isSelected: (id: string) => boolean;
-  selectedId?: string | string[];
+  selectedId?: InteractiveGroupSelectedId;
   setFocused: (id: string, props: Parameters<GeneratedInteractiveGroupActions['setFocusedByIndex']>[1]) => void;
   setSelected: GeneratedInteractiveGroupActions['setSelected'];
   unsetSelected: GeneratedInteractiveGroupActions['unsetSelected'];
@@ -173,19 +183,28 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
 
       const handleSelectedId = (id: string | undefined, allowReselect?: boolean) => {
         if (id && onSelect && (allowReselect || !wasPreviouslySelected(id))) {
-          onSelect(selectedEvent, {
-            ...items.getItemById(id),
-            id,
-            index: items.getIndexById(id),
-          });
+          onSelect(
+            selectedEvent,
+            {
+              ...items.getItemById(id),
+              id,
+              index: items.getIndexById(id),
+            },
+            selectedId,
+          );
         }
       };
 
       const handleUnselectedId = (id: string | undefined) => {
         if (id && onUnselect && !isCurrentlySelected(id)) {
-          onUnselect(unselectedEvent, {
-            id,
-          });
+          onUnselect(
+            unselectedEvent,
+            {
+              id,
+              index: items.getIndexById(id),
+            },
+            selectedId,
+          );
         }
       };
 

--- a/src/components/InteractiveGroup/useInteractiveGroup.ts
+++ b/src/components/InteractiveGroup/useInteractiveGroup.ts
@@ -197,7 +197,8 @@ export function useInteractiveGroup<
         allowReselect &&
         maxSelect === 1 &&
         previousState.current.selectedIds === selectedIds &&
-        previousState.current.selectedTime !== selectedTime
+        previousState.current.selectedTime !== selectedTime &&
+        selectedIds.length > 0
       ) {
         handleSelectedId(selectedIds[0], true);
       }

--- a/src/components/InteractiveGroup/useInteractiveGroup.ts
+++ b/src/components/InteractiveGroup/useInteractiveGroup.ts
@@ -1,11 +1,8 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import { Dispatch, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useElementEventListener } from '../../hooks/useElementEventListener';
 import { generateInteractiveGroupActions, GeneratedInteractiveGroupActions } from './generateInteractiveGroupActions';
-import { InteractiveGroupEventTypes } from './interactiveGroupActions';
-import {
-  interactiveGroupReducer as reducer,
-  getInteractiveGroupInitialState as getInitialState,
-} from './interactiveGroupReducer';
+import { InteractiveGroupEventTypes, InteractiveGroupStateAction } from './interactiveGroupActions';
+import { InteractiveGroupState } from './interactiveGroupReducer';
 import {
   selectFocusedIndex,
   selectFocusedEvent,
@@ -15,79 +12,84 @@ import {
   selectSelectedTime,
   selectUnselectedEvent,
   selectTriggeredId,
-  selectSelectedId,
+  selectSelectedIds,
 } from './interactiveGroupSelector';
-import { InteractiveGroupItemType } from './types';
+import { InteractiveGroupItemId, InteractiveGroupItemType } from './types';
 
-export type InteractiveGroupSelectedId = string | string[];
-
-export interface UseInteractiveGroupInterface {
-  allowMultiSelect?: boolean;
+export interface UseInteractiveGroupInterface<T extends InteractiveGroupItemId = string> {
   /* This will allow an already selected item to be re-triggered */
   allowReselect?: boolean;
-  disableUnselect?: boolean;
   /* This disables interaction across the whole group */
   disabled?: boolean;
-  initialSelected?: string | string[];
-  items: InteractiveGroupItemType[];
-  onItemClick?: (event: React.MouseEvent | React.TouchEvent, id: string) => void;
-  onItemFocus?: (event: InteractiveGroupEventTypes['event'] | undefined, props: { id: string; index: number }) => void;
+  initialSelected?: T[];
+  items: InteractiveGroupItemType<T>[];
+  /** Set minSelect to 0 to allow unselecting the current item */
+  minSelect?: number;
+  /** Set maxSelect to -1 to allow an unlimited amount */
+  maxSelect?: number;
+  onItemClick?: (event: React.MouseEvent | React.TouchEvent, id: T) => void;
+  onItemFocus?: (event: InteractiveGroupEventTypes['event'] | undefined, props: { id: T; index: number }) => void;
   onKeyDown?: (event: KeyboardEvent, props?: { used?: boolean }) => void;
-  onSelect?: (
-    event: InteractiveGroupEventTypes['event'],
-    props: { id?: string; index?: number },
-    selected?: InteractiveGroupSelectedId,
-  ) => void;
-  onUnselect?: (
-    event: InteractiveGroupEventTypes['event'],
-    props: { id?: string; index?: number },
-    selected?: InteractiveGroupSelectedId,
-  ) => void;
+  onSelect?: (event: InteractiveGroupEventTypes['event'], props: { id?: T; index?: number }, selected?: T[]) => void;
+  onSelectionChange?: (event: InteractiveGroupEventTypes['event'], selection: T[]) => void;
+  onUnselect?: (event: InteractiveGroupEventTypes['event'], props: { id?: T; index?: number }, selected?: T[]) => void;
   parentRef?: React.RefObject<HTMLElement>;
+  /** The reducer comes directly from useReducer() and is managed separately so that other components can manage the state */
+  reducer: [InteractiveGroupState<T>, Dispatch<InteractiveGroupStateAction<T>>];
   selectOnFocus?: boolean;
   /** If this is set and an item contains a link, when the item is selected that link will be triggered */
   triggerLinks?: boolean;
 }
 
-export type UseInteractiveGroupResponse<E extends HTMLElement = HTMLDivElement, I extends HTMLElement = HTMLElement> = {
+export type UseInteractiveGroupResponse<
+  T extends InteractiveGroupItemId = string,
+  E extends HTMLElement = HTMLDivElement,
+  I extends HTMLElement = HTMLElement
+> = {
   focusedIndex?: number;
-  handleItemClick: (event: React.MouseEvent<I> | React.TouchEvent<I>, id: string) => void;
+  handleItemClick: (event: React.MouseEvent<I> | React.TouchEvent<I>, id: T) => void;
   ref: React.Ref<E>;
-  isSelected: (id: string) => boolean;
-  selectedId?: InteractiveGroupSelectedId;
-  setFocused: (id: string, props: Parameters<GeneratedInteractiveGroupActions['setFocusedByIndex']>[1]) => void;
-  setSelected: GeneratedInteractiveGroupActions['setSelected'];
-  unsetSelected: GeneratedInteractiveGroupActions['unsetSelected'];
+  isSelected: (id: T) => boolean;
+  selectedIds?: T[];
+  setFocused: (id: T, props: Parameters<GeneratedInteractiveGroupActions<T>['setFocusedByIndex']>[1]) => void;
+  selectId: GeneratedInteractiveGroupActions<T>['selectId'];
+  unselectId: GeneratedInteractiveGroupActions<T>['unselectId'];
 };
 
 /**
+ * - T is the type of IDs allowed
  * - E is the type of the element that the returned ref gets attached to
  * - I is the type of item element
  */
-export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I extends HTMLElement = HTMLElement>({
-  allowMultiSelect,
+export function useInteractiveGroup<
+  T extends InteractiveGroupItemId = string,
+  E extends HTMLElement = HTMLDivElement,
+  I extends HTMLElement = HTMLElement
+>({
   allowReselect,
   disabled,
-  disableUnselect,
-  initialSelected,
   items: initialItems,
+  minSelect = 1,
+  maxSelect = 1,
   onItemClick,
   onItemFocus,
   onKeyDown,
   onSelect,
   onUnselect,
   parentRef,
+  reducer,
   selectOnFocus,
   triggerLinks,
-}: UseInteractiveGroupInterface): UseInteractiveGroupResponse<E, I> {
+}: UseInteractiveGroupInterface<T>): UseInteractiveGroupResponse<T, E, I> {
   const previousState = useRef<{
-    focusedIndex?: number;
-    triggeredTime?: number;
+    focusedIndex?: InteractiveGroupState<T>['focusedIndex'];
+    selectedIds?: InteractiveGroupState<T>['selectedIds'];
     selectedTime?: number;
-    selectedId?: string | string[];
+    triggeredTime?: number;
   }>({});
+
+  const [state, dispatch] = reducer;
   const ref = useRef<E>(null!);
-  const [state, dispatch] = useReducer(reducer, { initialItems, initialSelected }, getInitialState);
 
   const {
     focusFirst,
@@ -96,19 +98,19 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
     focusPrevious,
     selectFirst,
     selectFocused,
+    selectId,
     selectLast,
     selectNext,
     selectPrevious,
     setFocusedByIndex,
     setItems,
-    setSelected,
     toggleSelected,
     toggleSelectedFocused,
-    unsetSelected,
-  } = useMemo(() => generateInteractiveGroupActions(dispatch, disableUnselect, allowMultiSelect, allowReselect), [
+    unselectId,
+  } = useMemo(() => generateInteractiveGroupActions(dispatch, minSelect, maxSelect, allowReselect), [
     dispatch,
-    disableUnselect,
-    allowMultiSelect,
+    minSelect,
+    maxSelect,
     allowReselect,
   ]);
 
@@ -116,16 +118,14 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
   const focusedEvent = selectFocusedEvent(state);
   const focusedIndex = selectFocusedIndex(state);
   const selectedEvent = selectSelectedEvent(state);
-  const selectedId = selectSelectedId(state);
+  const selectedIds = selectSelectedIds(state);
   const selectedTime = selectSelectedTime(state);
   const triggeredId = selectTriggeredId(state);
   const triggeredTime = selectTriggeredTime(state);
   const unselectedEvent = selectUnselectedEvent(state);
 
-  const isSelected: UseInteractiveGroupResponse<E, I>['isSelected'] = id =>
-    allowMultiSelect
-      ? state.selectedId !== undefined && Array.isArray(state.selectedId) && state.selectedId.includes(id)
-      : state.selectedId === id;
+  const isSelected: UseInteractiveGroupResponse<T, E, I>['isSelected'] = id =>
+    !!(Array.isArray(state.selectedIds) && state.selectedIds.includes(id));
 
   // update the state if the items change
   useEffect(() => {
@@ -157,32 +157,15 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
   // call the onSelect or onUnselect callback if the selected item changes
   useEffect(() => {
     if (
-      (previousState.current.selectedId !== selectedId ||
+      (previousState.current.selectedIds !== selectedIds ||
         (allowReselect && previousState.current.selectedTime !== selectedTime)) &&
-      Object.prototype.hasOwnProperty.call(previousState.current, 'selectedId')
+      Object.prototype.hasOwnProperty.call(previousState.current, 'selectedIds')
     ) {
-      const wasPreviouslySelected = (id: string): boolean => {
-        if (previousState.current.selectedId) {
-          if (Array.isArray(previousState.current.selectedId)) {
-            return previousState.current.selectedId.includes(id);
-          }
-          return previousState.current.selectedId === id;
-        }
-        return false;
-      };
+      const wasPreviouslySelected = (id: T): boolean => previousState.current.selectedIds?.includes(id) || false;
+      const isCurrentlySelected = (id: T): boolean => selectedIds?.includes(id) || false;
 
-      const isCurrentlySelected = (id: string): boolean => {
-        if (selectedId) {
-          if (Array.isArray(selectedId)) {
-            return selectedId.includes(id);
-          }
-          return selectedId === id;
-        }
-        return false;
-      };
-
-      const handleSelectedId = (id: string | undefined, allowReselect?: boolean) => {
-        if (id && onSelect && (allowReselect || !wasPreviouslySelected(id))) {
+      const handleSelectedId = (id: T, allowReselect?: boolean) => {
+        if (id !== undefined && onSelect && (allowReselect || !wasPreviouslySelected(id))) {
           onSelect(
             selectedEvent,
             {
@@ -190,50 +173,42 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
               id,
               index: items.getIndexById(id),
             },
-            selectedId,
+            selectedIds,
           );
         }
       };
 
-      const handleUnselectedId = (id: string | undefined) => {
-        if (id && onUnselect && !isCurrentlySelected(id)) {
+      const handleUnselectedId = (id: T) => {
+        if (id !== undefined && onUnselect && !isCurrentlySelected(id)) {
           onUnselect(
             unselectedEvent,
             {
               id,
               index: items.getIndexById(id),
             },
-            selectedId,
+            selectedIds,
           );
         }
       };
 
       // trigger onUnselect callbacks for any former selections
-      if (onUnselect) {
-        if (Array.isArray(previousState.current.selectedId)) {
-          previousState.current.selectedId.forEach(id => handleUnselectedId(id));
-        } else {
-          handleUnselectedId(previousState.current.selectedId);
-        }
+      if (onUnselect && Array.isArray(previousState.current.selectedIds)) {
+        previousState.current.selectedIds.forEach(id => handleUnselectedId(id));
       }
 
       // trigger onSelect callbacks for any new selections
-      if (onSelect) {
-        if (Array.isArray(selectedId)) {
-          selectedId.forEach(id => handleSelectedId(id));
-        } else {
-          handleSelectedId(selectedId);
-        }
+      if (onSelect && Array.isArray(selectedIds)) {
+        selectedIds.forEach(id => handleSelectedId(id));
       }
 
       // trigger the onSelect callback for a re-select if not multi-select
       if (
         allowReselect &&
-        previousState.current.selectedId === selectedId &&
-        previousState.current.selectedTime !== selectedTime &&
-        !Array.isArray(selectedId)
+        maxSelect === 1 &&
+        previousState.current.selectedIds === selectedIds &&
+        previousState.current.selectedTime !== selectedTime
       ) {
-        handleSelectedId(selectedId, true);
+        handleSelectedId(selectedIds[0], true);
       }
 
       // manually trigger the link of <a> tags (if the target is the <a> tag don't trigger on click or Enter)
@@ -253,10 +228,10 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
       }
     }
 
-    previousState.current.selectedId = selectedId;
-    selectedId && (previousState.current.selectedTime = selectedTime);
+    previousState.current.selectedIds = selectedIds;
+    selectedIds && (previousState.current.selectedTime = selectedTime);
   }, [
-    selectedId,
+    selectedIds,
     selectedEvent,
     unselectedEvent,
     onSelect,
@@ -265,14 +240,15 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
     selectedTime,
     allowReselect,
     triggerLinks,
+    maxSelect,
   ]);
 
-  const setFocused: UseInteractiveGroupResponse['setFocused'] = useCallback(
+  const setFocused: UseInteractiveGroupResponse<T>['setFocused'] = useCallback(
     (id, props) => setFocusedByIndex(items.getIndexById(id), props),
     [items, setFocusedByIndex],
   );
 
-  const handleItemClick: UseInteractiveGroupResponse['handleItemClick'] = useCallback(
+  const handleItemClick: UseInteractiveGroupResponse<T>['handleItemClick'] = useCallback(
     (event, id) => {
       event.persist();
       event.stopPropagation();
@@ -354,9 +330,9 @@ export function useInteractiveGroup<E extends HTMLElement = HTMLDivElement, I ex
     handleItemClick,
     isSelected,
     ref,
-    selectedId,
+    selectedIds,
     setFocused,
-    setSelected,
-    unsetSelected,
+    selectId,
+    unselectId,
   };
 }

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -88,20 +88,19 @@ function ListBase<T extends ListElementType = 'ul'>(
       role: inactive ? 'list' : 'listbox',
       ...props,
     },
-    items &&
-      items.map(({ id, label, ...item }) => (
-        <ListItem<ListItemElementMap[T]>
-          as={listItemElement}
-          key={id}
-          inactive={inactive}
-          mimicSelectOnFocus={mimicSelectOnFocus}
-          transparent={transparent}
-          unstyled={unstyled}
-          {...(item as ListItemProps<ListItemElementMap[T]>)}
-        >
-          {label}
-        </ListItem>
-      )),
+    items?.map(({ id, label, ...item }) => (
+      <ListItem<ListItemElementMap[T]>
+        as={listItemElement}
+        key={id}
+        inactive={inactive}
+        mimicSelectOnFocus={mimicSelectOnFocus}
+        transparent={transparent}
+        unstyled={unstyled}
+        {...(item as ListItemProps<ListItemElementMap[T]>)}
+      >
+        {label}
+      </ListItem>
+    )),
     children,
   );
 }

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -10,6 +10,8 @@ export interface LocalListItemProps extends ThemeProps {
   disabled?: boolean;
   flush?: boolean;
   focused?: boolean;
+  /** A highlighted item is one that has a different style but no change in functionality */
+  highlighted?: boolean;
   inactive?: boolean;
   mimicSelectOnFocus?: boolean;
   onClick?: (event: React.MouseEvent | React.TouchEvent) => void;
@@ -31,6 +33,7 @@ function ListItemBase<T extends ListItemElementType = 'li'>(
     disabled,
     flush,
     focused,
+    highlighted,
     inactive,
     mimicSelectOnFocus,
     onClick,
@@ -54,6 +57,7 @@ function ListItemBase<T extends ListItemElementType = 'li'>(
             flush && styles['listItem--flush'],
             transparent && styles['listItem--transparent'],
             disabled && styles['is-disabled'],
+            highlighted && styles['is-highlighted'],
             inactive && styles['is-inactive'],
             showAsFocused && styles['is-focused'],
             showAsSelected && styles['is-selected'],

--- a/src/components/List/docs/list.mdx
+++ b/src/components/List/docs/list.mdx
@@ -29,6 +29,7 @@ See also the [InteractiveList](../compositions/InteractiveList) composition whic
             { id: 'normal1', label: 'Normal' },
             { id: 'normal2', label: 'Normal' },
             { id: 'normal3', label: 'Normal' },
+            { id: 'highlighted', label: 'Highlighted', highlighted: true },
             { id: 'disabled', label: 'Disabled', disabled: true },
             { id: 'inactive', label: 'Inactive', inactive: true },
           ]}
@@ -44,6 +45,7 @@ See also the [InteractiveList](../compositions/InteractiveList) composition whic
             { id: 'normal1', label: 'Normal' },
             { id: 'normal2', label: 'Normal' },
             { id: 'normal3', label: 'Normal' },
+            { id: 'highlighted', label: 'Highlighted', highlighted: true },
             { id: 'disabled', label: 'Disabled', disabled: true },
             { id: 'inactive', label: 'Inactive', inactive: true },
           ]}
@@ -59,6 +61,7 @@ See also the [InteractiveList](../compositions/InteractiveList) composition whic
             { id: 'normal1', label: 'Normal' },
             { id: 'normal2', label: 'Normal' },
             { id: 'normal3', label: 'Normal' },
+            { id: 'highlighted', label: 'Highlighted', highlighted: true },
             { id: 'disabled', label: 'Disabled', disabled: true },
             { id: 'inactive', label: 'Inactive', inactive: true },
           ]}
@@ -76,6 +79,7 @@ See also the [InteractiveList](../compositions/InteractiveList) composition whic
             { id: 'normal1', label: 'Normal' },
             { id: 'normal2', label: 'Normal' },
             { id: 'normal3', label: 'Normal' },
+            { id: 'highlighted', label: 'Highlighted', highlighted: true },
             { id: 'disabled', label: 'Disabled', disabled: true },
             { id: 'inactive', label: 'Inactive', inactive: true },
           ]}

--- a/src/components/List/styles/List.module.css
+++ b/src/components/List/styles/List.module.css
@@ -67,6 +67,12 @@ ul.unlist {
       background-color: transparent;
     }
 
+    &.is-highlighted {
+      @mixin prepareShade;
+      @mixin makeShade var(--list-item-selected-background-color);
+      color: var(--list-item-selected-background-color);
+    }
+
     &.is-selected {
       background-color: var(--list-item-selected-background-color);
       color: var(--list-item-selected-text-color);

--- a/src/compositions/Accordion/Accordion.tsx
+++ b/src/compositions/Accordion/Accordion.tsx
@@ -18,10 +18,9 @@ export type AccordionRenderChildren = (
 ) => React.ReactElement<HTMLDivElement>;
 
 export interface AccordionProps
-  extends Pick<UseInteractiveGroupInterface, 'allowMultiSelect' | 'initialSelected' | 'onSelect'>,
+  extends Pick<UseInteractiveGroupInterface, 'maxSelect' | 'minSelect' | 'initialSelected' | 'onSelect'>,
     Pick<AccordionListProps, 'duration' | 'easing' | 'horizontal' | 'items' | 'variant'>,
     ThemeProps {
-  allowUnselect?: boolean;
   children?: AccordionRenderChildren;
   className?: string;
   listProps?: Omit<
@@ -44,8 +43,6 @@ export interface AccordionProps
 }
 
 export function Accordion({
-  allowMultiSelect,
-  allowUnselect,
   children,
   className,
   contrast,
@@ -55,6 +52,8 @@ export function Accordion({
   initialSelected,
   items,
   listProps,
+  maxSelect,
+  minSelect,
   onSelect,
   style,
   themeId,
@@ -71,12 +70,12 @@ export function Accordion({
 
   return (
     <ListRegistryProvider>
-      <InteractiveGroupProvider<HTMLDivElement, HTMLDivElement>
-        allowMultiSelect={allowMultiSelect}
-        disableUnselect={!allowUnselect && !allowMultiSelect}
+      <InteractiveGroupProvider<string, HTMLDivElement, HTMLDivElement>
         onSelect={onSelect}
         items={items}
-        initialSelected={initialSelected || (items[0] && items[0].id)}
+        initialSelected={initialSelected || (items[0] && [items[0].id])}
+        maxSelect={maxSelect}
+        minSelect={minSelect}
         {...props}
       >
         {

--- a/src/compositions/Accordion/Accordion.tsx
+++ b/src/compositions/Accordion/Accordion.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { ThemeProps } from '../../types';
 import { useComponentId } from '../../hooks/useComponentId';
-import { InteractiveGroupProvider } from '../../components/InteractiveGroup/InteractiveGroupProvider';
-import { UseInteractiveGroupInterface } from '../../components/InteractiveGroup/useInteractiveGroup';
+import {
+  InteractiveGroupProvider,
+  InteractiveGroupProviderProps,
+} from '../../components/InteractiveGroup/InteractiveGroupProvider';
 import { ListRegistryProvider } from '../../components/ListRegistry/ListRegistryProvider';
 import { AccordionContainer } from './AccordionContainer';
 import { AccordionList, AccordionListProps } from './AccordionList';
@@ -18,7 +20,7 @@ export type AccordionRenderChildren = (
 ) => React.ReactElement<HTMLDivElement>;
 
 export interface AccordionProps
-  extends Pick<UseInteractiveGroupInterface, 'maxSelect' | 'minSelect' | 'initialSelected' | 'onSelect'>,
+  extends Pick<InteractiveGroupProviderProps, 'maxSelect' | 'minSelect' | 'initialSelected' | 'onSelect'>,
     Pick<AccordionListProps, 'duration' | 'easing' | 'horizontal' | 'items' | 'variant'>,
     ThemeProps {
   children?: AccordionRenderChildren;

--- a/src/compositions/Accordion/AccordionList.tsx
+++ b/src/compositions/Accordion/AccordionList.tsx
@@ -57,7 +57,7 @@ export const AccordionList = React.forwardRef<HTMLDivElement, AccordionListProps
     const variant = contrast ? 'contrast' : initVariant;
 
     const { handleItemClick, isSelected, focusedIndex } = useContext<
-      InteractiveGroupContextValue<HTMLDivElement, HTMLDivElement>
+      InteractiveGroupContextValue<string, HTMLDivElement, HTMLDivElement>
     >(InteractiveGroupContext);
 
     const combineRefs = makeCombineRefs<HTMLDivElement>(ref, forwardedRef);

--- a/src/compositions/Accordion/docs/accordion.mdx
+++ b/src/compositions/Accordion/docs/accordion.mdx
@@ -5,13 +5,13 @@ route: /compositions/Accordion
 ---
 
 import { Playground, Props } from 'docz';
-import { AccordionList } from '../AccordionList';
-import { Accordion, AccordionContent, AccordionLabel, AccordionContainer } from '../index';
 import { Button } from 'components/Button';
 import { Rhythm } from 'components/Rhythm';
-import { ThemeWrapper } from 'docs/helpers/ThemeWrapper';
 import { Looper } from 'docs/helpers/Looper';
 import { PageTitle } from 'docs/helpers/PageTitle';
+import { ThemeWrapper } from 'docs/helpers/ThemeWrapper';
+import { AccordionList } from '../AccordionList';
+import { Accordion, AccordionContent, AccordionLabel, AccordionContainer } from '../index';
 
 <PageTitle title="Accordion" src="compositions/Accordion" />
 
@@ -21,18 +21,47 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper>
-    <Accordion onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: 'First', content: <Rhythm px={5} py={2}>First panel</Rhythm> },
-      { id: 'second', label: 'Second', content: <Rhythm px={5} py={2}>Second panel</Rhythm> },
-      { id: 'third', label: 'Third', content: <Rhythm px={5} py={2}>Third panel</Rhythm> },
-      { id: 'fourth', label: 'Fourth', content: (
-        <Rhythm px={5} py={2} wrapper="div">
-          <Looper start={0} end={40} render={i => (
-            <span>Fourth panel{' '}</span>
-          )} />
-        </Rhythm>
-      )},
-    ]} />
+    <Accordion
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: 'First',
+          content: (
+            <Rhythm px={5} py={2}>
+              First panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'second',
+          label: 'Second',
+          content: (
+            <Rhythm px={5} py={2}>
+              Second panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'third',
+          label: 'Third',
+          content: (
+            <Rhythm px={5} py={2}>
+              Third panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'fourth',
+          label: 'Fourth',
+          content: (
+            <Rhythm px={5} py={2} wrapper="div">
+              <Looper start={0} end={40} render={i => <span>Fourth panel </span>} />
+            </Rhythm>
+          ),
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 
@@ -40,18 +69,48 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper>
-    <Accordion allowMultiSelect onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: 'First', content: <Rhythm px={5} py={2}>First panel</Rhythm> },
-      { id: 'second', label: 'Second', content: <Rhythm px={5} py={2}>Second panel</Rhythm> },
-      { id: 'third', label: 'Third', content: <Rhythm px={5} py={2}>Third panel</Rhythm> },
-      { id: 'fourth', label: 'Fourth', content: (
-        <Rhythm px={5} py={2} wrapper="div">
-          <Looper start={0} end={40} render={i => (
-            <span>Fourth panel{' '}</span>
-          )} />
-        </Rhythm>
-      )},
-    ]} />
+    <Accordion
+      maxSelect={-1}
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: 'First',
+          content: (
+            <Rhythm px={5} py={2}>
+              First panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'second',
+          label: 'Second',
+          content: (
+            <Rhythm px={5} py={2}>
+              Second panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'third',
+          label: 'Third',
+          content: (
+            <Rhythm px={5} py={2}>
+              Third panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'fourth',
+          label: 'Fourth',
+          content: (
+            <Rhythm px={5} py={2} wrapper="div">
+              <Looper start={0} end={40} render={i => <span>Fourth panel </span>} />
+            </Rhythm>
+          ),
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 
@@ -59,12 +118,49 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper>
-    <Accordion horizontal onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: '1', content: <Rhythm my={2} mx={4}>First</Rhythm> },
-      { id: 'second', label: '2', content: <Rhythm my={2} mx={4}>Second</Rhythm> },
-      { id: 'third', label: '3', content: <Rhythm my={2} mx={4}>Third</Rhythm>, disabled: true },
-      { id: 'fourth', label: '4', content: <Rhythm my={2} mx={4}>Fourth</Rhythm> },
-    ]} />
+    <Accordion
+      horizontal
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: '1',
+          content: (
+            <Rhythm my={2} mx={4}>
+              First
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'second',
+          label: '2',
+          content: (
+            <Rhythm my={2} mx={4}>
+              Second
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'third',
+          label: '3',
+          content: (
+            <Rhythm my={2} mx={4}>
+              Third
+            </Rhythm>
+          ),
+          disabled: true,
+        },
+        {
+          id: 'fourth',
+          label: '4',
+          content: (
+            <Rhythm my={2} mx={4}>
+              Fourth
+            </Rhythm>
+          ),
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 
@@ -74,12 +170,33 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper>
-    <Accordion initialSelected="second" onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: ({ selected }) => `First${selected ? ' is selected': ''}`, content: ({ selected }) => <Rhythm px={5} py={2}>{`First panel${selected ? ' is selected': ''}`}</Rhythm> },
-      { id: 'second', label: ({ selected }) => `Second${selected ? ' is selected': ''}`, content: ({ selected }) => <Rhythm px={5} py={2}>{`Second panel${selected ? ' is selected': ''}`}</Rhythm> },
-      { id: 'third', label: ({ selected }) => `Third${selected ? ' is selected': ''}`, content: ({ selected }) => <Rhythm px={5} py={2}>{`Third panel${selected ? ' is selected': ''}`}</Rhythm>, disabled: true },
-      { id: 'fourth', label: ({ selected }) => `Fourth${selected ? ' is selected': ''}`, content: ({ selected }) => <Rhythm px={5} py={2}>{`Fourth panel${selected ? ' is selected': ''}`}</Rhythm> },
-    ]} />
+    <Accordion
+      initialSelected={['second']}
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: ({ selected }) => `First${selected ? ' is selected' : ''}`,
+          content: ({ selected }) => <Rhythm px={5} py={2}>{`First panel${selected ? ' is selected' : ''}`}</Rhythm>,
+        },
+        {
+          id: 'second',
+          label: ({ selected }) => `Second${selected ? ' is selected' : ''}`,
+          content: ({ selected }) => <Rhythm px={5} py={2}>{`Second panel${selected ? ' is selected' : ''}`}</Rhythm>,
+        },
+        {
+          id: 'third',
+          label: ({ selected }) => `Third${selected ? ' is selected' : ''}`,
+          content: ({ selected }) => <Rhythm px={5} py={2}>{`Third panel${selected ? ' is selected' : ''}`}</Rhythm>,
+          disabled: true,
+        },
+        {
+          id: 'fourth',
+          label: ({ selected }) => `Fourth${selected ? ' is selected' : ''}`,
+          content: ({ selected }) => <Rhythm px={5} py={2}>{`Fourth panel${selected ? ' is selected' : ''}`}</Rhythm>,
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 
@@ -87,12 +204,49 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper contrast>
-    <Accordion contrast onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: 'First', content: <Rhythm px={5} py={2}>First panel</Rhythm> },
-      { id: 'second', label: 'Second', content: <Rhythm px={5} py={2}>Second panel</Rhythm> },
-      { id: 'third', label: 'Third', content: <Rhythm px={5} py={2}>Third panel</Rhythm>, disabled: true },
-      { id: 'fourth', label: 'Fourth', content: <Rhythm px={5} py={2}>Fourth panel</Rhythm> },
-    ]} />
+    <Accordion
+      contrast
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: 'First',
+          content: (
+            <Rhythm px={5} py={2}>
+              First panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'second',
+          label: 'Second',
+          content: (
+            <Rhythm px={5} py={2}>
+              Second panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'third',
+          label: 'Third',
+          content: (
+            <Rhythm px={5} py={2}>
+              Third panel
+            </Rhythm>
+          ),
+          disabled: true,
+        },
+        {
+          id: 'fourth',
+          label: 'Fourth',
+          content: (
+            <Rhythm px={5} py={2}>
+              Fourth panel
+            </Rhythm>
+          ),
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 
@@ -100,12 +254,49 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 
 <Playground>
   <ThemeWrapper>
-    <Accordion allowUnselect onSelect={(event, id) => console.log(id)} items={[
-      { id: 'first', label: 'First', content: <Rhythm px={5} py={2}>First panel</Rhythm> },
-      { id: 'second', label: 'Second', content: <Rhythm px={5} py={2}>Second panel</Rhythm> },
-      { id: 'third', label: 'Third', content: <Rhythm px={5} py={2}>Third panel</Rhythm>, disabled: true },
-      { id: 'fourth', label: 'Fourth', content: <Rhythm px={5} py={2}>Fourth panel</Rhythm> },
-    ]} />
+    <Accordion
+      minSelect={0}
+      onSelect={(event, id) => console.log(id)}
+      items={[
+        {
+          id: 'first',
+          label: 'First',
+          content: (
+            <Rhythm px={5} py={2}>
+              First panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'second',
+          label: 'Second',
+          content: (
+            <Rhythm px={5} py={2}>
+              Second panel
+            </Rhythm>
+          ),
+        },
+        {
+          id: 'third',
+          label: 'Third',
+          content: (
+            <Rhythm px={5} py={2}>
+              Third panel
+            </Rhythm>
+          ),
+          disabled: true,
+        },
+        {
+          id: 'fourth',
+          label: 'Fourth',
+          content: (
+            <Rhythm px={5} py={2}>
+              Fourth panel
+            </Rhythm>
+          ),
+        },
+      ]}
+    />
   </ThemeWrapper>
 </Playground>
 

--- a/src/compositions/Accordion/types.ts
+++ b/src/compositions/Accordion/types.ts
@@ -1,6 +1,6 @@
 import { InteractiveGroupItemType } from '../../components/InteractiveGroup/types';
 
-export type AccordionItemType = InteractiveGroupItemType & {
+export type AccordionItemType = InteractiveGroupItemType<string> & {
   content: React.ReactNode;
   contentProps?: Record<string, unknown>;
   iconOnly?: boolean;

--- a/src/compositions/Dropdown/Dropdown.tsx
+++ b/src/compositions/Dropdown/Dropdown.tsx
@@ -243,7 +243,7 @@ function DropdownBase(
       dispatch({
         type:
           event &&
-          maxSelect <= 1 &&
+          maxSelect === 1 &&
           (event.type === 'click' || (event.type === 'keydown' && 'key' in event && event.key === 'Enter'))
             ? ACTIONS.SET_SELECTED_AND_HIDE_DROPDOWN
             : ACTIONS.SET_SELECTED,
@@ -263,7 +263,7 @@ function DropdownBase(
         dispatch({
           type:
             event &&
-            (maxSelect === -1 || maxSelect > 1) &&
+            maxSelect === 1 &&
             (event.type === 'click' || (event.type === 'keydown' && 'key' in event && event.key === 'Enter'))
               ? ACTIONS.SET_SELECTED_AND_HIDE_DROPDOWN
               : ACTIONS.SET_SELECTED,

--- a/src/compositions/Dropdown/Dropdown.tsx
+++ b/src/compositions/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@emotion/css';
 import debounce from 'lodash.debounce';
-import React, { Reducer, useCallback, useEffect, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { StateColor, ThemeProps } from '../../types';
 import { useClickAndEscape } from '../../hooks/useClickAndEscape';
@@ -12,12 +12,7 @@ import { SearchIcon } from '../../icons';
 import { ArrowDownIcon } from '../../icons/ArrowDownIcon';
 import { SpinnerIcon } from '../../icons/SpinnerIcon';
 import { Textbox, TextboxProps } from '../../components/Form/Textbox/Textbox';
-import { InteractiveGroupStateAction } from '../../components/InteractiveGroup/interactiveGroupActions';
-import {
-  getInteractiveGroupInitialState,
-  interactiveGroupReducer,
-  InteractiveGroupState,
-} from '../../components/InteractiveGroup/interactiveGroupReducer';
+import { UnmanagedInteractiveListProps } from '../InteractiveList';
 import { DropdownContent, DropdownContentProps, DropdownContentHandles } from './DropdownContent';
 import { dropdownActions as ACTIONS } from './dropdownActions';
 import { dropdownReducer } from './dropdownReducer';
@@ -50,11 +45,9 @@ export interface DropdownProps
   className?: string;
   disabled?: boolean;
   disabledIds?: Array<DropdownOption['id']>;
-  dropdownContent: typeof DropdownContent;
   iconBefore?: TextboxProps['iconBefore'];
   iconAfter?: TextboxProps['iconAfter'];
   id?: string;
-  initialSelected?: DropdownOption[];
   inputRef?: React.Ref<HTMLInputElement>;
   inputVariant?: DropdownInputVariant;
   filterOptions?: (filter: string) => Promise<DropdownOption[]>;
@@ -71,6 +64,7 @@ export interface DropdownProps
   onUnselect?: (option: DropdownOption, selectedIds: string[] | undefined) => void;
   options: DropdownOption[];
   readOnlyValue?: React.ReactChild;
+  reducer: UnmanagedInteractiveListProps['reducer'];
   ref?: React.Ref<HTMLDivElement>;
   transitional?: boolean;
   translations?: DropdownTranslations;
@@ -86,12 +80,10 @@ function DropdownBase(
     contrast,
     disabled,
     disabledIds,
-    dropdownContent: DropdownContent,
     emptyNotification,
     iconAfter: initIconAfter,
     iconBefore: initIconBefore,
     id,
-    initialSelected,
     inputRef: forwardedInputRef,
     inputVariant = 'underline',
     label,
@@ -100,7 +92,7 @@ function DropdownBase(
     listSize,
     listColor,
     maxSelect = 1,
-    minSelect = 1,
+    minSelect = 0,
     onInputChange,
     onClear,
     onClose,
@@ -114,6 +106,7 @@ function DropdownBase(
     options,
     placeholder,
     readOnlyValue,
+    reducer,
     themeId: initThemeId,
     unthemed,
     transitional,
@@ -123,12 +116,6 @@ function DropdownBase(
   }: DropdownProps,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ): React.ReactElement<DropdownProps, 'div'> {
-  const reducer = useReducer<Reducer<InteractiveGroupState<string>, InteractiveGroupStateAction<string>>>(
-    interactiveGroupReducer,
-    getInteractiveGroupInitialState({ items: [], selectedIds: initialSelected?.map(({ id }) => id) }),
-  );
-
-  // the state is managed by the interactive list, but this is for reading
   const [selectedState] = reducer;
 
   const ref = useRef<HTMLDivElement>(null!);

--- a/src/compositions/Dropdown/DropdownContent.tsx
+++ b/src/compositions/Dropdown/DropdownContent.tsx
@@ -3,7 +3,6 @@ import React, { useImperativeHandle, useMemo, useRef } from 'react';
 import { MergeElementProps, ThemeProps } from '../../types';
 import { useAccessibility } from '../../context';
 import { useDeepFocus } from '../../hooks/useDeepFocus';
-import { InteractiveGroupSelectedId } from '../../components/InteractiveGroup/useInteractiveGroup';
 import { InteractiveList, InteractiveListProps } from '../InteractiveList/InteractiveList';
 import { DropdownEmpty, DropdownEmptyProps } from './DropdownEmpty';
 import { DropdownState } from './dropdownReducer';
@@ -19,7 +18,6 @@ import {
 import { getListDefaults, isItemSelected } from './utils';
 
 export interface LocalDropdownContentProps extends ThemeProps {
-  allowMultiSelect?: boolean;
   /** This is used by DropdownWithTags so an item can be added, removed and re-added */
   allowReselect?: boolean;
   className?: string;
@@ -32,6 +30,8 @@ export interface LocalDropdownContentProps extends ThemeProps {
   listColor?: DropdownListColor;
   listSize?: DropdownListSize;
   listVariant?: DropdownListVariant;
+  maxSelect?: number;
+  minSelect?: number;
   onItemFocus: InteractiveListProps['onItemFocus'];
   onListBlur: React.FocusEventHandler<HTMLDivElement>;
   onListFocus: React.FocusEventHandler<HTMLDivElement>;
@@ -52,7 +52,6 @@ export interface DropdownContentHandles {
 
 function DropdownContentBase(
   {
-    allowMultiSelect,
     allowReselect,
     className,
     parentRef,
@@ -66,6 +65,8 @@ function DropdownContentBase(
     listColor,
     listSize,
     listVariant,
+    maxSelect,
+    minSelect,
     onItemFocus,
     onListBlur,
     onListFocus,
@@ -81,8 +82,8 @@ function DropdownContentBase(
   forwardedRef: React.ForwardedRef<DropdownContentHandles>,
 ): React.ReactElement<HTMLDivElement> | null {
   const accessible = useAccessibility();
-  const initialSelected = useRef<InteractiveGroupSelectedId | undefined>(
-    (Array.isArray(state.selected) ? state.selected.map(({ id }) => id) : state.selected?.id) || undefined,
+  const initialSelected = useRef<string[]>(
+    state.selected?.filter(({ id }) => id !== undefined).map(({ id }) => id) || [],
   );
 
   const containerRef = useRef<HTMLDivElement>(null!);
@@ -139,7 +140,6 @@ function DropdownContentBase(
     >
       <div className={cx(styles.dropdownOptions, isEmpty && styles['is-empty'])}>
         <InteractiveList
-          allowMultiSelect={allowMultiSelect}
           allowReselect={allowReselect}
           color={listColor || listDefaults.color}
           contrast={contrast}
@@ -150,6 +150,8 @@ function DropdownContentBase(
           items={items}
           // mimicSelectOnFocus is necessary so that keyboard navigation doesn't keep selecting items but it looks like a regular dropdown
           mimicSelectOnFocus
+          maxSelect={maxSelect}
+          minSelect={minSelect}
           onItemFocus={onItemFocus}
           onKeyDown={onListKeyDown}
           onSelect={onSelect}

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -110,17 +110,17 @@ export function DropdownWithTags({
   }, []);
 
   const handleSelect = useCallback<NonNullable<DropdownProps['onSelect']>>(
-    (option, selectedIds) => {
-      selectId(option.id);
-      onSelect && onSelect(option, selectedIds);
+    (id, selectedIds) => {
+      selectId(id);
+      onSelect && onSelect(id, selectedIds);
     },
     [onSelect, selectId],
   );
 
   const handleUnselect = useCallback<NonNullable<DropdownProps['onUnselect']>>(
-    (option, selectedIds) => {
-      unselectId(option.id);
-      onUnselect && onUnselect(option, selectedIds);
+    (id, selectedIds) => {
+      unselectId(id);
+      onUnselect && onUnselect(id, selectedIds);
     },
     [onUnselect, unselectId],
   );

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -29,6 +29,8 @@ export function DropdownWithTags({
   contrast,
   id,
   initialSelected = [],
+  minSelect = 1,
+  maxSelect = -1,
   onSelect,
   onSelectionChange,
   onUnselect,
@@ -90,7 +92,7 @@ export function DropdownWithTags({
     isDropdownOpen.current = false;
   }, []);
 
-  const handleSelect = useCallback<DropdownProps['onSelect']>(
+  const handleSelect = useCallback<NonNullable<DropdownProps['onSelect']>>(
     (option, selected) => {
       setSelected(selected as DropdownOption[]);
       onSelect && onSelect(option, selected);
@@ -98,7 +100,7 @@ export function DropdownWithTags({
     [onSelect],
   );
 
-  const handleUnselect = useCallback<DropdownProps['onUnselect']>(
+  const handleUnselect = useCallback<NonNullable<DropdownProps['onUnselect']>>(
     (option, selected) => {
       setSelected((selected ? selected : []) as DropdownOption[]);
       onUnselect && onUnselect(option, selected);
@@ -125,6 +127,7 @@ export function DropdownWithTags({
         dropdownContent={DropdownContent}
         id={id}
         inputRef={dropdownRef}
+        maxSelect={maxSelect}
         onClose={handleClose}
         onOpen={handleOpen}
         onSelect={handleSelect}

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -64,7 +64,7 @@ export function DropdownWithTags({
   const dropdownRef = useRef<HTMLInputElement>(null!);
   const tagRef = useRef<HTMLButtonElement>(null!);
   const isDropdownOpen = useRef<boolean>(false);
-  const previousNumSelected = useRef<number>(initialSelected?.length || 0);
+  const previousSelectedIds = useRef<string[]>(state.selectedIds);
   const { generateComponentId } = useComponentId();
   const themeId = useThemeId(initThemeId);
 
@@ -89,17 +89,17 @@ export function DropdownWithTags({
    * that it doesn't take focus away from it.
    */
   useEffect(() => {
-    if (!isDropdownOpen.current && state.selectedIds.length !== previousNumSelected.current) {
-      if (state.selectedIds.length < previousNumSelected.current) {
+    if (!isDropdownOpen.current && state.selectedIds !== previousSelectedIds.current) {
+      if (state.selectedIds.length < previousSelectedIds.current.length) {
         if (state.selectedIds.length >= 1) {
           tagRef.current?.focus();
         } else {
           dropdownRef.current?.focus();
         }
       }
-      previousNumSelected.current = state.selectedIds.length;
     }
-  }, [state.selectedIds.length]);
+    previousSelectedIds.current = state.selectedIds;
+  }, [state.selectedIds]);
 
   const handleOpen = useCallback(() => {
     isDropdownOpen.current = true;

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -93,19 +93,19 @@ export function DropdownWithTags({
   }, []);
 
   const handleSelect = useCallback<NonNullable<DropdownProps['onSelect']>>(
-    (option, selected) => {
-      setSelected(selected as DropdownOption[]);
-      onSelect && onSelect(option, selected);
+    (option, selectedIds) => {
+      setSelected(options.filter(({ id }) => selectedIds.includes(id)));
+      onSelect && onSelect(option, selectedIds);
     },
-    [onSelect],
+    [onSelect, options],
   );
 
   const handleUnselect = useCallback<NonNullable<DropdownProps['onUnselect']>>(
-    (option, selected) => {
-      setSelected((selected ? selected : []) as DropdownOption[]);
-      onUnselect && onUnselect(option, selected);
+    (option, selectedIds) => {
+      setSelected(options.filter(({ id }) => selectedIds?.includes(id)));
+      onUnselect && onUnselect(option, selectedIds);
     },
-    [onUnselect],
+    [onUnselect, options],
   );
 
   const removeItem = (itemId: string) => {

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -121,7 +121,6 @@ export function DropdownWithTags({
   return (
     <Flex direction="column">
       <Dropdown
-        allowMultiSelect
         contrast={contrast}
         dropdownContent={DropdownContent}
         id={id}

--- a/src/compositions/Dropdown/InlineDropdown.tsx
+++ b/src/compositions/Dropdown/InlineDropdown.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Dropdown, DropdownProps } from './Dropdown';
-import { DropdownContent } from './DropdownContent';
-
-export function InlineDropdown({ ...props }: Omit<DropdownProps, 'dropdownContent'>) {
-  return <Dropdown dropdownContent={DropdownContent} {...props} />;
-}
-
-InlineDropdown.displayName = 'InlineDropdown';

--- a/src/compositions/Dropdown/ManagedDropdown.tsx
+++ b/src/compositions/Dropdown/ManagedDropdown.tsx
@@ -1,0 +1,31 @@
+import React, { Reducer, useReducer } from 'react';
+import { InteractiveGroupStateAction } from '../../components/InteractiveGroup/interactiveGroupActions';
+import {
+  getInteractiveGroupInitialState,
+  interactiveGroupReducer,
+  InteractiveGroupState,
+} from '../../components/InteractiveGroup/interactiveGroupReducer';
+import { Dropdown, DropdownProps } from './Dropdown';
+import { DropdownOption } from './types';
+
+export interface ManagedDropdownProps extends Omit<DropdownProps, 'reducer'> {
+  initialSelected: DropdownOption[];
+}
+
+/** The dropdown is a controlled component */
+function ManagedDropdownBase(
+  { initialSelected, options, ...props }: ManagedDropdownProps,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+): React.ReactElement<ManagedDropdownProps, 'div'> {
+  const reducer = useReducer<Reducer<InteractiveGroupState<string>, InteractiveGroupStateAction<string>>>(
+    interactiveGroupReducer,
+    getInteractiveGroupInitialState({ items: [], selectedIds: initialSelected?.map(({ id }) => id) }),
+  );
+
+  return <Dropdown options={options} reducer={reducer} ref={forwardedRef} {...props} />;
+}
+
+export const ManagedDropdown = React.forwardRef(ManagedDropdownBase) as typeof ManagedDropdownBase;
+
+ManagedDropdownBase.displayName = 'ManagedDropdownBase';
+ManagedDropdown.displayName = 'ManagedDropdown';

--- a/src/compositions/Dropdown/docs/dropdown.mdx
+++ b/src/compositions/Dropdown/docs/dropdown.mdx
@@ -37,9 +37,10 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
               inputVariant={variant}
               label="Super awesome dropdown"
               layout="raised"
-              onChange={value => console.log('change', value)}
               onItemFocus={(event, value) => console.log('focus', value)}
               onSelect={value => console.log('select', value)}
+              onUnselect={value => console.log('unselect', value)}
+              onSelectionChange={options => console.log('selected', options)}
               options={options}
               transitional
             />
@@ -65,7 +66,33 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
               inputVariant={variant}
               label="Super awesome dropdown"
               layout="contained"
-              onChange={value => console.log('change', value)}
+              onSelect={value => console.log('select', value)}
+              options={options}
+              transitional
+            />
+          </div>
+        )}
+      />
+    </Flex>
+  </ThemeWrapper>
+</Playground>
+
+## Multi-select dropdown
+
+<Playground>
+  <ThemeWrapper>
+    <br />
+    <Flex direction="row" justifyContent="space-between" full wrap>
+      <Looper
+        list={variants}
+        render={variant => (
+          <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
+            <InlineDropdown
+              allowMultiSelect
+              initialSelected={[options[3]]}
+              inputVariant={variant}
+              label="Super awesome dropdown"
+              layout="contained"
               onSelect={value => console.log('select', value)}
               options={options}
               transitional
@@ -87,13 +114,13 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
             <InlineDropdown
+              filterOptions={handleFilter}
               iconAfter={<TagIcon size={12} />}
               initialSelected={options[3]}
               inputVariant={variant}
               label="Super awesome dropdown"
-              onChange={value => console.log(value)}
               onClear={value => console.log('clear')}
-              onFilter={handleFilter}
+              onInputChange={value => console.log(value)}
               onSelect={value => console.log('select', value)}
               onSubmit={(event, value) =>
                 !options.some(option => option.id === value) && options.push({ id: value, label: value })
@@ -119,10 +146,10 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         <div style={{ height: 300, maxWidth: 300 }}>
           <InlineDropdown
             emptyNotification={filter ? `No options were found for "${filter}".` : ''}
+            filterOptions={handleFilter}
             label="Super awesome dropdown"
-            onChange={setFilter}
             onClear={value => console.log('clear')}
-            onFilter={handleFilter}
+            onInputChange={setFilter}
             onSelect={value => console.log('select', value)}
             onSubmit={(event, value) =>
               !options.some(option => option.id === value) && options.push({ id: value, label: value })
@@ -142,7 +169,6 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
     <div style={{ maxWidth: 300 }}>
       <InlineDropdown
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={[]}
         transitional
@@ -157,10 +183,10 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
       <InlineDropdown
+        filterOptions={handleEmptyFilter}
         iconBefore={<SearchIcon size={14} />}
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
-        onFilter={handleEmptyFilter}
+        onInputChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={[]}
         transitional
@@ -180,7 +206,6 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         id="demo-danger-dropdown"
         initialSelected={options[3]}
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={options}
         validity="danger"
@@ -198,7 +223,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         id="demo-danger-dropdown"
         initialSelected={options[3]}
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
+        onInputChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={options}
         validity="warning"
@@ -216,7 +241,6 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         id="demo-danger-dropdown"
         initialSelected={options[3]}
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={options}
         validity="success"
@@ -235,7 +259,6 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         id="demo-contrast-dropdown"
         initialSelected={options[3]}
         label="Super awesome dropdown"
-        onChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={options}
       />
@@ -252,7 +275,6 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
       initialSelected={options[3]}
       label="Super awesome dropdown"
       layout="contained"
-      onChange={value => console.log('change', value)}
       onSelect={value => console.log('select', value)}
       options={options}
       style={{
@@ -292,13 +314,13 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
   <ThemeWrapper withThemeId style={{ height: '300px' }}>
     {({ themeId }) => (
       <MultiVariantDropdown
+        filterOptions={handleFilter}
         iconBefore={<SearchIcon size={14} />}
         initialSelected={options[3]}
         label="Super awesome dropdown"
         layout="contained"
-        onChange={value => console.log('change', value)}
         onClear={value => console.log('clear')}
-        onFilter={handleFilter}
+        onInputChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
         options={options}
         outline="unboxed"

--- a/src/compositions/Dropdown/docs/dropdown.mdx
+++ b/src/compositions/Dropdown/docs/dropdown.mdx
@@ -14,7 +14,7 @@ import { Looper } from 'docs/helpers/Looper';
 import { PageTitle } from 'docs/helpers/PageTitle';
 import { StateWrapper } from 'docs/helpers/StateWrapper';
 import { ThemeWrapper } from 'docs/helpers/ThemeWrapper';
-import { Dropdown, DropdownContent, DropdownEmpty, InlineDropdown } from '../index';
+import { Dropdown, DropdownContent, DropdownEmpty, ManagedDropdown } from '../index';
 import { MultiVariantDropdown } from './helpers/MultiVariantDropdown';
 import { options, handleFilter, handleEmptyFilter } from './helpers/options';
 import { variants } from './helpers/variants.js';
@@ -32,7 +32,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         list={variants}
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
-            <InlineDropdown
+            <ManagedDropdown
               initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
@@ -61,7 +61,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         list={variants}
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
-            <InlineDropdown
+            <ManagedDropdown
               initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
@@ -89,7 +89,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         list={variants}
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
-            <InlineDropdown
+            <ManagedDropdown
               initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
@@ -117,7 +117,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         list={variants}
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
-            <InlineDropdown
+            <ManagedDropdown
               filterOptions={handleFilter}
               iconAfter={<TagIcon size={12} />}
               initialSelected={[options[3]]}
@@ -148,7 +148,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
     <StateWrapper initialState={''}>
       {({ state: filter, setState: setFilter }) => (
         <div style={{ height: 300, maxWidth: 300 }}>
-          <InlineDropdown
+          <ManagedDropdown
             emptyNotification={filter ? `No options were found for "${filter}".` : ''}
             filterOptions={handleFilter}
             label="Super awesome dropdown"
@@ -171,7 +171,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         label="Super awesome dropdown"
         onSelect={value => console.log('select', value)}
         options={[]}
@@ -186,7 +186,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         filterOptions={handleEmptyFilter}
         iconBefore={<SearchIcon size={14} />}
         label="Super awesome dropdown"
@@ -206,7 +206,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         id="demo-danger-dropdown"
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
@@ -223,7 +223,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         id="demo-danger-dropdown"
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
@@ -241,7 +241,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         id="demo-danger-dropdown"
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
@@ -258,7 +258,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 <Playground>
   <ThemeWrapper contrast style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
-      <InlineDropdown
+      <ManagedDropdown
         contrast
         id="demo-contrast-dropdown"
         initialSelected={[options[3]]}
@@ -274,7 +274,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 
 <Playground>
   <div style={{ height: 300, maxWidth: 300, marginLeft: 20, marginRight: 20 }}>
-    <InlineDropdown
+    <ManagedDropdown
       id="demo-contrast-dropdown"
       initialSelected={[options[3]]}
       label="Super awesome dropdown"
@@ -357,6 +357,10 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
 ### Dropdown
 
 <Props of={Dropdown} />
+
+### ManagedDropdown
+
+<Props of={ManagedDropdown} />
 
 ### DropdownEmpty
 

--- a/src/compositions/Dropdown/docs/dropdown.mdx
+++ b/src/compositions/Dropdown/docs/dropdown.mdx
@@ -118,7 +118,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
             <ManagedDropdown
-              filterOptions={handleFilter}
+              getFilteredOptions={handleFilter}
               iconAfter={<TagIcon size={12} />}
               initialSelected={[options[3]]}
               inputVariant={variant}
@@ -150,7 +150,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
         <div style={{ height: 300, maxWidth: 300 }}>
           <ManagedDropdown
             emptyNotification={filter ? `No options were found for "${filter}".` : ''}
-            filterOptions={handleFilter}
+            getFilteredOptions={handleFilter}
             label="Super awesome dropdown"
             onClear={value => console.log('clear')}
             onInputChange={setFilter}
@@ -187,7 +187,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: 300 }}>
       <ManagedDropdown
-        filterOptions={handleEmptyFilter}
+        getFilteredOptions={handleEmptyFilter}
         iconBefore={<SearchIcon size={14} />}
         label="Super awesome dropdown"
         onInputChange={value => console.log('change', value)}
@@ -318,7 +318,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
   <ThemeWrapper withThemeId style={{ height: '300px' }}>
     {({ themeId }) => (
       <MultiVariantDropdown
-        filterOptions={handleFilter}
+        getFilteredOptions={handleFilter}
         iconBefore={<SearchIcon size={14} />}
         initialSelected={[options[3]]}
         label="Super awesome dropdown"

--- a/src/compositions/Dropdown/docs/dropdown.mdx
+++ b/src/compositions/Dropdown/docs/dropdown.mdx
@@ -33,14 +33,14 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
             <InlineDropdown
-              initialSelected={options[3]}
+              initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
               layout="raised"
               onItemFocus={(event, value) => console.log('focus', value)}
               onSelect={value => console.log('select', value)}
               onUnselect={value => console.log('unselect', value)}
-              onSelectionChange={options => console.log('selected', options)}
+              onSelectionChange={value => console.log('selection change', value)}
               options={options}
               transitional
             />
@@ -62,11 +62,13 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
             <InlineDropdown
-              initialSelected={options[3]}
+              initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
               layout="contained"
               onSelect={value => console.log('select', value)}
+              onUnselect={value => console.log('unselect', value)}
+              onSelectionChange={value => console.log('selection change', value)}
               options={options}
               transitional
             />
@@ -88,12 +90,14 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={variant => (
           <div style={{ height: 300, width: '30%', maxWidth: 300, minWidth: 200, marginLeft: 20, marginRight: 20 }}>
             <InlineDropdown
-              allowMultiSelect
               initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
               layout="contained"
+              maxSelect={-1}
               onSelect={value => console.log('select', value)}
+              onUnselect={value => console.log('unselect', value)}
+              onSelectionChange={value => console.log('selection change', value)}
               options={options}
               transitional
             />
@@ -116,7 +120,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
             <InlineDropdown
               filterOptions={handleFilter}
               iconAfter={<TagIcon size={12} />}
-              initialSelected={options[3]}
+              initialSelected={[options[3]]}
               inputVariant={variant}
               label="Super awesome dropdown"
               onClear={value => console.log('clear')}
@@ -204,7 +208,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
     <div style={{ maxWidth: 300 }}>
       <InlineDropdown
         id="demo-danger-dropdown"
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onSelect={value => console.log('select', value)}
         options={options}
@@ -221,7 +225,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
     <div style={{ maxWidth: 300 }}>
       <InlineDropdown
         id="demo-danger-dropdown"
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onInputChange={value => console.log('change', value)}
         onSelect={value => console.log('select', value)}
@@ -239,7 +243,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
     <div style={{ maxWidth: 300 }}>
       <InlineDropdown
         id="demo-danger-dropdown"
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onSelect={value => console.log('select', value)}
         options={options}
@@ -257,7 +261,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
       <InlineDropdown
         contrast
         id="demo-contrast-dropdown"
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onSelect={value => console.log('select', value)}
         options={options}
@@ -272,7 +276,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
   <div style={{ height: 300, maxWidth: 300, marginLeft: 20, marginRight: 20 }}>
     <InlineDropdown
       id="demo-contrast-dropdown"
-      initialSelected={options[3]}
+      initialSelected={[options[3]]}
       label="Super awesome dropdown"
       layout="contained"
       onSelect={value => console.log('select', value)}
@@ -316,7 +320,7 @@ A searchable dropdown is similar to a filterable dropdown except that it starts 
       <MultiVariantDropdown
         filterOptions={handleFilter}
         iconBefore={<SearchIcon size={14} />}
-        initialSelected={options[3]}
+        initialSelected={[options[3]]}
         label="Super awesome dropdown"
         layout="contained"
         onClear={value => console.log('clear')}

--- a/src/compositions/Dropdown/docs/dropdownWithTags.mdx
+++ b/src/compositions/Dropdown/docs/dropdownWithTags.mdx
@@ -111,7 +111,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onChange={value => console.log(value)}
-        onFilter={handleFilter}
+        filterOptions={handleFilter}
         onSelect={value => console.log('select', value)}
         onSubmit={(event, value) =>
           !options.some(option => option.id === value) && options.push({ id: value, label: value })

--- a/src/compositions/Dropdown/docs/dropdownWithTags.mdx
+++ b/src/compositions/Dropdown/docs/dropdownWithTags.mdx
@@ -107,10 +107,10 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: '100%', marginLeft: 20, marginRight: 20 }}>
       <DropdownWithTags
+        getFilteredOptions={handleFilter}
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onChange={value => console.log(value)}
-        filterOptions={handleFilter}
         onSelect={value => console.log('select', value)}
         onSubmit={(event, value) =>
           !options.some(option => option.id === value) && options.push({ id: value, label: value })

--- a/src/compositions/Dropdown/docs/dropdownWithTags.mdx
+++ b/src/compositions/Dropdown/docs/dropdownWithTags.mdx
@@ -107,7 +107,6 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
   <ThemeWrapper style={{ height: '300px' }}>
     <div style={{ maxWidth: '100%', marginLeft: 20, marginRight: 20 }}>
       <DropdownWithTags
-        iconAfter={<SearchIcon size={14} />}
         initialSelected={[options[3]]}
         label="Super awesome dropdown"
         onChange={value => console.log(value)}

--- a/src/compositions/Dropdown/docs/helpers/MultiVariantDropdown.js
+++ b/src/compositions/Dropdown/docs/helpers/MultiVariantDropdown.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useSafeTimeout } from '../../../../hooks/useSafeTimeout';
-import { InlineDropdown } from '../../InlineDropdown';
+import { ManagedDropdown } from '../../ManagedDropdown';
 
 const CLOSE_TIMEOUT_ID = 'close';
 
@@ -19,7 +19,7 @@ export function MultiVariantDropdown({ style, ...props }) {
   };
 
   return (
-    <InlineDropdown
+    <ManagedDropdown
       contrast={contrast}
       onOpen={handleOpen}
       onClose={handleClose}

--- a/src/compositions/Dropdown/dropdownActions.ts
+++ b/src/compositions/Dropdown/dropdownActions.ts
@@ -59,12 +59,12 @@ export type DropdownStateActionSetOptions = {
 
 export type DropdownStateActionSetSelected = {
   type: dropdownActions.SET_SELECTED;
-  selected: DropdownOption | undefined;
+  selected: DropdownOption | DropdownOption[] | undefined;
 };
 
 export type DropdownStateActionSetSelectedAndHideDropdown = {
   type: dropdownActions.SET_SELECTED_AND_HIDE_DROPDOWN;
-  selected: DropdownOption | undefined;
+  selected: DropdownOption | DropdownOption[] | undefined;
 };
 
 export type DropdownStateActionShowDropdown = {

--- a/src/compositions/Dropdown/dropdownActions.ts
+++ b/src/compositions/Dropdown/dropdownActions.ts
@@ -59,12 +59,12 @@ export type DropdownStateActionSetOptions = {
 
 export type DropdownStateActionSetSelected = {
   type: dropdownActions.SET_SELECTED;
-  selected: DropdownOption | DropdownOption[] | undefined;
+  selected: DropdownOption[] | undefined;
 };
 
 export type DropdownStateActionSetSelectedAndHideDropdown = {
   type: dropdownActions.SET_SELECTED_AND_HIDE_DROPDOWN;
-  selected: DropdownOption | DropdownOption[] | undefined;
+  selected: DropdownOption[] | undefined;
 };
 
 export type DropdownStateActionShowDropdown = {

--- a/src/compositions/Dropdown/dropdownActions.ts
+++ b/src/compositions/Dropdown/dropdownActions.ts
@@ -1,5 +1,3 @@
-import { DropdownOption } from './types';
-
 export enum dropdownActions {
   CLEAR_FILTER = 'CLEAR_FILTER',
   HIDE_DROPDOWN = 'HIDE_DROPDOWN',
@@ -8,12 +6,9 @@ export enum dropdownActions {
   SET_FILTER = 'SET_FILTER',
   SET_INPUT_FOCUS = 'SET_INPUT_FOCUS',
   SET_LIST_FOCUS = 'SET_LIST_FOCUS',
-  SET_OPTIONS = 'SET_OPTIONS',
-  SET_SELECTED = 'SET_SELECTED',
-  SET_SELECTED_AND_HIDE_DROPDOWN = 'SET_SELECTED_AND_HIDE_DROPDOWN',
   SHOW_DROPDOWN = 'SHOW_DROPDOWN',
   TOGGLE_DROPDOWN = 'TOGGLE_DROPDOWN',
-  UNSET_SELECTED = 'UNSET_SELECTED',
+  UNSET_BUSY = 'UNSET_BUSY',
   UNSET_CLEAR_FOCUS = 'UNSET_CLEAR_FOCUS',
   UNSET_INPUT_FOCUS = 'UNSET_INPUT_FOCUS',
   UNSET_LIST_FOCUS = 'UNSET_LIST_FOCUS',
@@ -48,25 +43,6 @@ export type DropdownStateActionSetListFocus = {
   type: dropdownActions.SET_LIST_FOCUS;
 };
 
-export type DropdownStateActionSetOptions = {
-  type: dropdownActions.SET_OPTIONS;
-  options: Array<{
-    id: string;
-    value?: string | number;
-    label: React.ReactElement | string;
-  }>;
-};
-
-export type DropdownStateActionSetSelected = {
-  type: dropdownActions.SET_SELECTED;
-  selected: DropdownOption[] | undefined;
-};
-
-export type DropdownStateActionSetSelectedAndHideDropdown = {
-  type: dropdownActions.SET_SELECTED_AND_HIDE_DROPDOWN;
-  selected: DropdownOption[] | undefined;
-};
-
 export type DropdownStateActionShowDropdown = {
   type: dropdownActions.SHOW_DROPDOWN;
 };
@@ -75,8 +51,8 @@ export type DropdownStateActionToggleDropdown = {
   type: dropdownActions.TOGGLE_DROPDOWN;
 };
 
-export type DropdownStateActionUnsetSelected = {
-  type: dropdownActions.UNSET_SELECTED;
+export type DropdownStateActionUnsetBusy = {
+  type: dropdownActions.UNSET_BUSY;
 };
 
 export type DropdownStateActionUnsetClearFocus = {
@@ -99,12 +75,9 @@ export type DropdownStateAction =
   | DropdownStateActionSetFilter
   | DropdownStateActionSetInputFocus
   | DropdownStateActionSetListFocus
-  | DropdownStateActionSetOptions
-  | DropdownStateActionSetSelected
-  | DropdownStateActionSetSelectedAndHideDropdown
   | DropdownStateActionShowDropdown
   | DropdownStateActionToggleDropdown
-  | DropdownStateActionUnsetSelected
+  | DropdownStateActionUnsetBusy
   | DropdownStateActionUnsetClearFocus
   | DropdownStateActionUnsetInputFocus
   | DropdownStateActionUnsetListFocus;

--- a/src/compositions/Dropdown/dropdownReducer.ts
+++ b/src/compositions/Dropdown/dropdownReducer.ts
@@ -1,5 +1,4 @@
 import { dropdownActions as ACTIONS, DropdownStateAction } from './dropdownActions';
-import { DropdownOption } from './types';
 
 export type DropdownState = {
   busy?: boolean;
@@ -9,8 +8,6 @@ export type DropdownState = {
   inputFocus?: boolean;
   listFocus?: boolean;
   listVisible?: boolean;
-  options?: DropdownOption[];
-  selected?: DropdownOption[];
 };
 
 export function dropdownReducer(state: DropdownState, action: DropdownStateAction): DropdownState {
@@ -19,7 +16,6 @@ export function dropdownReducer(state: DropdownState, action: DropdownStateActio
       return {
         ...state,
         input: '',
-        options: undefined,
       };
 
     case ACTIONS.HIDE_DROPDOWN:
@@ -58,26 +54,6 @@ export function dropdownReducer(state: DropdownState, action: DropdownStateActio
         listFocus: true,
       };
 
-    case ACTIONS.SET_OPTIONS:
-      return {
-        ...state,
-        busy: false,
-        options: action.options,
-      };
-
-    case ACTIONS.SET_SELECTED:
-      return {
-        ...state,
-        selected: action.selected,
-      };
-
-    case ACTIONS.SET_SELECTED_AND_HIDE_DROPDOWN:
-      return {
-        ...state,
-        selected: action.selected,
-        listVisible: false,
-      };
-
     case ACTIONS.SHOW_DROPDOWN:
       return {
         ...state,
@@ -88,12 +64,6 @@ export function dropdownReducer(state: DropdownState, action: DropdownStateActio
       return {
         ...state,
         listVisible: !state.listVisible,
-      };
-
-    case ACTIONS.UNSET_SELECTED:
-      return {
-        ...state,
-        selected: undefined,
       };
 
     case ACTIONS.UNSET_CLEAR_FOCUS:

--- a/src/compositions/Dropdown/dropdownReducer.ts
+++ b/src/compositions/Dropdown/dropdownReducer.ts
@@ -66,6 +66,12 @@ export function dropdownReducer(state: DropdownState, action: DropdownStateActio
         listVisible: !state.listVisible,
       };
 
+    case ACTIONS.UNSET_BUSY:
+      return {
+        ...state,
+        busy: false,
+      };
+
     case ACTIONS.UNSET_CLEAR_FOCUS:
       return {
         ...state,

--- a/src/compositions/Dropdown/dropdownReducer.ts
+++ b/src/compositions/Dropdown/dropdownReducer.ts
@@ -10,7 +10,7 @@ export type DropdownState = {
   listFocus?: boolean;
   listVisible?: boolean;
   options?: DropdownOption[];
-  selected?: DropdownOption;
+  selected?: DropdownOption | DropdownOption[];
 };
 
 export function dropdownReducer(state: DropdownState, action: DropdownStateAction): DropdownState {

--- a/src/compositions/Dropdown/dropdownReducer.ts
+++ b/src/compositions/Dropdown/dropdownReducer.ts
@@ -10,7 +10,7 @@ export type DropdownState = {
   listFocus?: boolean;
   listVisible?: boolean;
   options?: DropdownOption[];
-  selected?: DropdownOption | DropdownOption[];
+  selected?: DropdownOption[];
 };
 
 export function dropdownReducer(state: DropdownState, action: DropdownStateAction): DropdownState {

--- a/src/compositions/Dropdown/index.ts
+++ b/src/compositions/Dropdown/index.ts
@@ -4,5 +4,5 @@ export * from './DropdownContent';
 export * from './DropdownEmpty';
 export * from './dropdownReducer';
 export * from './DropdownWithTags';
-export * from './InlineDropdown';
+export * from './ManagedDropdown';
 export * from './types';

--- a/src/compositions/Dropdown/types.ts
+++ b/src/compositions/Dropdown/types.ts
@@ -13,3 +13,8 @@ export type DropdownLayout = 'raised' | 'contained';
 export type DropdownListVariant = 'bordered' | 'shadowed' | 'divided' | 'unboxed';
 export type DropdownListSize = 'xsmall' | 'small' | 'medium';
 export type DropdownListColor = 'primary' | 'minimal';
+
+export type DropdownTranslations = {
+  numSelectedSingular: string;
+  numSelectedPlural: string;
+};

--- a/src/compositions/Dropdown/utils.ts
+++ b/src/compositions/Dropdown/utils.ts
@@ -34,7 +34,7 @@ export const getDropdownSelectedView = ({
 
   if (selectedState.selectedIds && selectedState.selectedIds.length > 0) {
     const selectedId = selectedState.selectedIds[0];
-    const selectedOption = options.find(({ id }) => id === selectedId);
+    const selectedOption = options?.find(({ id }) => id === selectedId);
     return selectedOption?.selectedLabel || selectedOption?.label;
   }
 

--- a/src/compositions/Dropdown/utils.ts
+++ b/src/compositions/Dropdown/utils.ts
@@ -10,15 +10,15 @@ import {
 } from './types';
 
 export const getDropdownSelectedView = ({
-  allowMultiSelect,
+  maxSelect,
   state,
   translations,
 }: {
-  allowMultiSelect?: boolean;
+  maxSelect: number;
   state: DropdownState;
   translations: DropdownTranslations;
 }): React.ReactChild | undefined => {
-  if (allowMultiSelect) {
+  if (maxSelect === -1 || maxSelect > 1) {
     const { numSelectedSingular, numSelectedPlural } = translations;
 
     if (Array.isArray(state.selected) && state.selected.length > 0) {
@@ -30,8 +30,8 @@ export const getDropdownSelectedView = ({
     return undefined;
   }
 
-  if (state.selected && !Array.isArray(state.selected)) {
-    return state.selected.selectedLabel || state.selected.label;
+  if (state.selected && state.selected.length > 0) {
+    return state.selected[0]?.selectedLabel || state.selected[0]?.label;
   }
 
   return undefined;
@@ -39,11 +39,7 @@ export const getDropdownSelectedView = ({
 
 export const isItemSelected = (item: DropdownOption, selected: DropdownState['selected']): boolean => {
   if (item && selected) {
-    if (Array.isArray(selected)) {
-      return selected.some(({ id }) => id === item.id);
-    } else {
-      return selected.id === item.id;
-    }
+    return selected.some(({ id }) => id === item.id);
   }
   return false;
 };

--- a/src/compositions/Dropdown/utils.ts
+++ b/src/compositions/Dropdown/utils.ts
@@ -1,47 +1,44 @@
 import { substituteTranslationArgs } from '../../hooks/useTranslations';
-import { DropdownState } from './dropdownReducer';
+import { InteractiveGroupState } from '../../components/InteractiveGroup/interactiveGroupReducer';
 import {
   DropdownListSize,
   DropdownListVariant,
-  DropdownOption,
   DropdownTranslations,
   DropdownLayout,
   DropdownListColor,
+  DropdownOption,
 } from './types';
 
 export const getDropdownSelectedView = ({
+  options,
   maxSelect,
-  state,
+  selectedState,
   translations,
 }: {
+  options: DropdownOption[];
   maxSelect: number;
-  state: DropdownState;
+  selectedState: InteractiveGroupState<string>;
   translations: DropdownTranslations;
 }): React.ReactChild | undefined => {
   if (maxSelect === -1 || maxSelect > 1) {
     const { numSelectedSingular, numSelectedPlural } = translations;
 
-    if (Array.isArray(state.selected) && state.selected.length > 0) {
+    if (Array.isArray(selectedState.selectedIds) && selectedState.selectedIds.length > 0) {
       return substituteTranslationArgs(
-        state.selected.length === 1 ? numSelectedSingular : numSelectedPlural,
-        state.selected.length,
+        selectedState.selectedIds.length === 1 ? numSelectedSingular : numSelectedPlural,
+        selectedState.selectedIds.length,
       );
     }
     return undefined;
   }
 
-  if (state.selected && state.selected.length > 0) {
-    return state.selected[0]?.selectedLabel || state.selected[0]?.label;
+  if (selectedState.selectedIds && selectedState.selectedIds.length > 0) {
+    const selectedId = selectedState.selectedIds[0];
+    const selectedOption = options.find(({ id }) => id === selectedId);
+    return selectedOption?.selectedLabel || selectedOption?.label;
   }
 
   return undefined;
-};
-
-export const isItemSelected = (item: DropdownOption, selected: DropdownState['selected']): boolean => {
-  if (item && selected) {
-    return selected.some(({ id }) => id === item.id);
-  }
-  return false;
 };
 
 export const getListDefaults = (layout: DropdownLayout) => {

--- a/src/compositions/Dropdown/utils.ts
+++ b/src/compositions/Dropdown/utils.ts
@@ -1,0 +1,65 @@
+import { substituteTranslationArgs } from '../../hooks/useTranslations';
+import { DropdownState } from './dropdownReducer';
+import {
+  DropdownListSize,
+  DropdownListVariant,
+  DropdownOption,
+  DropdownTranslations,
+  DropdownLayout,
+  DropdownListColor,
+} from './types';
+
+export const getDropdownSelectedView = ({
+  allowMultiSelect,
+  state,
+  translations,
+}: {
+  allowMultiSelect?: boolean;
+  state: DropdownState;
+  translations: DropdownTranslations;
+}): React.ReactChild | undefined => {
+  if (allowMultiSelect) {
+    const { numSelectedSingular, numSelectedPlural } = translations;
+
+    if (Array.isArray(state.selected) && state.selected.length > 0) {
+      return substituteTranslationArgs(
+        state.selected.length === 1 ? numSelectedSingular : numSelectedPlural,
+        state.selected.length,
+      );
+    }
+    return undefined;
+  }
+
+  if (state.selected && !Array.isArray(state.selected)) {
+    return state.selected.selectedLabel || state.selected.label;
+  }
+
+  return undefined;
+};
+
+export const isItemSelected = (item: DropdownOption, selected: DropdownState['selected']): boolean => {
+  if (item && selected) {
+    if (Array.isArray(selected)) {
+      return selected.some(({ id }) => id === item.id);
+    } else {
+      return selected.id === item.id;
+    }
+  }
+  return false;
+};
+
+export const getListDefaults = (layout: DropdownLayout) => {
+  const defaults = {
+    raised: {
+      color: 'primary' as DropdownListColor,
+      size: 'medium' as DropdownListSize,
+      variant: 'unboxed' as DropdownListVariant,
+    },
+    contained: {
+      color: 'primary' as DropdownListColor,
+      size: 'medium' as DropdownListSize,
+      variant: 'unboxed' as DropdownListVariant,
+    },
+  };
+  return defaults[layout] || defaults.raised;
+};

--- a/src/compositions/InteractiveList/InteractiveList.tsx
+++ b/src/compositions/InteractiveList/InteractiveList.tsx
@@ -11,13 +11,13 @@ import { List, ListProps } from '../../components/List';
 import { InteractiveListItem, InteractiveListItemProps } from './InteractiveListItem';
 
 type ExplicitProviderProps = Pick<
-  InteractiveGroupProviderProps<HTMLUListElement, HTMLLIElement>,
-  | 'allowMultiSelect'
+  InteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
   | 'allowReselect'
-  | 'disableUnselect'
   | 'disabled'
   | 'initialSelected'
   | 'items'
+  | 'maxSelect'
+  | 'minSelect'
   | 'onItemClick'
   | 'onItemFocus'
   | 'onKeyDown'
@@ -35,7 +35,7 @@ export interface LocalInteractiveListProps extends ExplicitProviderProps {
   items: (Omit<InteractiveListItemProps, 'onClick'> & { selectedLabel?: string })[];
   listComponent?: typeof List;
   providerProps?: Omit<
-    InteractiveGroupProviderProps<HTMLUListElement, HTMLLIElement>,
+    InteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
     keyof ExplicitProviderProps | 'children'
   >;
   unstyled?: boolean;
@@ -45,16 +45,16 @@ export type InteractiveListProps = MergeProps<ListProps<'ul'>, LocalInteractiveL
 
 function InteractiveListBase(
   {
-    allowMultiSelect,
     allowReselect,
     children,
     disabled,
-    disableUnselect,
     focused,
     initialSelected,
     items,
     listComponent,
+    maxSelect,
     mimicSelectOnFocus,
+    minSelect,
     onItemClick,
     onItemFocus,
     onKeyDown,
@@ -82,13 +82,13 @@ function InteractiveListBase(
   const ListComponent = listComponent || List;
 
   return (
-    <InteractiveGroupProvider<HTMLUListElement, HTMLLIElement>
-      allowMultiSelect={allowMultiSelect}
+    <InteractiveGroupProvider<string, HTMLUListElement, HTMLLIElement>
       allowReselect={allowReselect}
       disabled={disabled}
-      disableUnselect={disableUnselect}
       initialSelected={initialSelected}
       items={items}
+      maxSelect={maxSelect}
+      minSelect={minSelect}
       onItemClick={onItemClick}
       onItemFocus={onItemFocus}
       onKeyDown={onKeyDown}

--- a/src/compositions/InteractiveList/InteractiveList.tsx
+++ b/src/compositions/InteractiveList/InteractiveList.tsx
@@ -1,158 +1,32 @@
-import React, { useRef } from 'react';
-import { MergeProps, ThemeProps } from '../../types';
-import { useThemeId } from '../../hooks/useThemeId';
-import { makeCombineRefs } from '../../utils/combineRefs';
-import { InteractiveGroupConsumer } from '../../components/InteractiveGroup/InteractiveGroupConsumer';
+import React, { Reducer, useReducer } from 'react';
 import {
-  InteractiveGroupProvider,
-  InteractiveGroupProviderProps,
-} from '../../components/InteractiveGroup/InteractiveGroupProvider';
-import { List, ListProps } from '../../components/List';
-import { InteractiveListItem, InteractiveListItemProps } from './InteractiveListItem';
+  InteractiveGroupState,
+  InteractiveGroupStateAction,
+  interactiveGroupReducer,
+  getInteractiveGroupInitialState,
+} from '../../components/InteractiveGroup';
+import { UnmanagedInteractiveList, UnmanagedInteractiveListProps } from './UnmanagedInteractiveList';
 
-type ExplicitProviderProps = Pick<
-  InteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
-  | 'allowReselect'
-  | 'disabled'
-  | 'initialSelected'
-  | 'items'
-  | 'maxSelect'
-  | 'minSelect'
-  | 'onItemClick'
-  | 'onItemFocus'
-  | 'onKeyDown'
-  | 'onSelect'
-  | 'onUnselect'
-  | 'parentRef'
-  | 'selectOnFocus'
-  | 'triggerLinks'
->;
+export type InteractiveListProps = Omit<UnmanagedInteractiveListProps, 'reducer'>;
 
-export interface LocalInteractiveListProps extends ExplicitProviderProps {
-  children: React.ReactNode;
-  /** The focused state can be set outside of this component so that focus styles can be applied when, for example, a parent is focused */
-  focused?: boolean;
-  items: (Omit<InteractiveListItemProps, 'onClick'> & { selectedLabel?: string })[];
-  listComponent?: typeof List;
-  providerProps?: Omit<
-    InteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
-    keyof ExplicitProviderProps | 'children'
-  >;
-  unstyled?: boolean;
-}
-
-export type InteractiveListProps = MergeProps<ListProps<'ul'>, LocalInteractiveListProps> & ThemeProps;
-
+/** The interactive list is a managed wrapper around the unmanaged interactive list */
 function InteractiveListBase(
-  {
-    allowReselect,
-    children,
-    disabled,
-    focused,
-    initialSelected,
-    items,
-    listComponent,
-    maxSelect,
-    mimicSelectOnFocus,
-    minSelect,
-    onItemClick,
-    onItemFocus,
-    onKeyDown,
-    onSelect,
-    onUnselect,
-    parentRef,
-    providerProps,
-    rounded,
-    selectOnFocus,
-    themeId: initThemeId,
-    transparent,
-    triggerLinks,
-    unstyled,
-    unthemed,
-    ...props
-  }: InteractiveListProps,
+  { initialSelected, items, ...props }: InteractiveListProps,
   forwardedRef: React.ForwardedRef<HTMLUListElement>,
 ): React.ReactElement {
-  const ref = useRef<HTMLUListElement>(null!);
-  const combineRefs = makeCombineRefs<HTMLUListElement>(ref, forwardedRef);
-
-  const themeId = useThemeId(initThemeId);
-
-  // this allows the consumer to passed a styled list which can react to accessible, focused, etc.
-  const ListComponent = listComponent || List;
+  const reducer = useReducer<Reducer<InteractiveGroupState<string>, InteractiveGroupStateAction<string>>>(
+    interactiveGroupReducer,
+    getInteractiveGroupInitialState({ items, selectedIds: initialSelected }),
+  );
 
   return (
-    <InteractiveGroupProvider<string, HTMLUListElement, HTMLLIElement>
-      allowReselect={allowReselect}
-      disabled={disabled}
+    <UnmanagedInteractiveList
       initialSelected={initialSelected}
       items={items}
-      maxSelect={maxSelect}
-      minSelect={minSelect}
-      onItemClick={onItemClick}
-      onItemFocus={onItemFocus}
-      onKeyDown={onKeyDown}
-      onSelect={onSelect}
-      onUnselect={onUnselect}
-      parentRef={parentRef}
-      selectOnFocus={selectOnFocus}
-      triggerLinks={triggerLinks}
-      {...providerProps}
-    >
-      <InteractiveGroupConsumer>
-        {({ focusedIndex, handleItemClick, isSelected }) =>
-          items && items.length ? (
-            <ListComponent<'ul'>
-              as="ul"
-              focused={focused}
-              inactive={disabled}
-              mimicSelectOnFocus={mimicSelectOnFocus}
-              ref={combineRefs}
-              rounded={rounded}
-              tabIndex={disabled ? -1 : 0}
-              themeId={themeId}
-              transparent={transparent}
-              unstyled={unstyled}
-              unthemed={unthemed}
-              {...(props as Omit<
-                ListProps<'ul'>,
-                | 'as'
-                | 'children'
-                | 'focused'
-                | 'inactive'
-                | 'items'
-                | 'onBlur'
-                | 'onFocus'
-                | 'ref'
-                | 'tabIndex'
-                | 'themeId'
-                | 'unstyled'
-              >)}
-            >
-              {items.map(({ id, label, disabled, ...itemProps }, index) => {
-                return (
-                  <InteractiveListItem
-                    disabled={disabled}
-                    focused={focusedIndex === index}
-                    id={id}
-                    key={id}
-                    label={label}
-                    mimicSelectOnFocus={mimicSelectOnFocus}
-                    onClick={handleItemClick}
-                    selected={isSelected(id)}
-                    transparent={transparent}
-                    unstyled={unstyled}
-                    {...(itemProps as Omit<InteractiveListItemProps, 'id' | 'label' | 'onClick'>)}
-                  />
-                );
-              })}
-            </ListComponent>
-          ) : (
-            children
-          )
-        }
-      </InteractiveGroupConsumer>
-    </InteractiveGroupProvider>
+      reducer={reducer}
+      ref={forwardedRef}
+      {...props}
+    />
   );
 }
 

--- a/src/compositions/InteractiveList/InteractiveList.tsx
+++ b/src/compositions/InteractiveList/InteractiveList.tsx
@@ -1,13 +1,16 @@
-import React, { Reducer, useReducer } from 'react';
+import React, { Reducer, useEffect, useReducer } from 'react';
 import {
+  getInteractiveGroupInitialState,
   InteractiveGroupState,
   InteractiveGroupStateAction,
   interactiveGroupReducer,
-  getInteractiveGroupInitialState,
+  InteractiveGroupProviderProps,
+  interactiveGroupActions as ACTIONS,
 } from '../../components/InteractiveGroup';
 import { UnmanagedInteractiveList, UnmanagedInteractiveListProps } from './UnmanagedInteractiveList';
 
-export type InteractiveListProps = Omit<UnmanagedInteractiveListProps, 'reducer'>;
+export type InteractiveListProps = Omit<UnmanagedInteractiveListProps, 'reducer'> &
+  Pick<InteractiveGroupProviderProps, 'initialSelected'>;
 
 /** The interactive list is a managed wrapper around the unmanaged interactive list */
 function InteractiveListBase(
@@ -19,15 +22,18 @@ function InteractiveListBase(
     getInteractiveGroupInitialState({ items, selectedIds: initialSelected }),
   );
 
-  return (
-    <UnmanagedInteractiveList
-      initialSelected={initialSelected}
-      items={items}
-      reducer={reducer}
-      ref={forwardedRef}
-      {...props}
-    />
-  );
+  const [, dispatch] = reducer;
+
+  // this is a managed component so we must watch for items changes
+  useEffect(() => {
+    dispatch({
+      items: items || [],
+      timestamp: Date.now(),
+      type: ACTIONS.SET_ITEMS,
+    });
+  }, [dispatch, items]);
+
+  return <UnmanagedInteractiveList reducer={reducer} ref={forwardedRef} {...props} />;
 }
 
 export const InteractiveList = React.forwardRef(InteractiveListBase) as typeof InteractiveListBase;

--- a/src/compositions/InteractiveList/UnmanagedInteractiveList.tsx
+++ b/src/compositions/InteractiveList/UnmanagedInteractiveList.tsx
@@ -1,0 +1,168 @@
+import React, { useRef } from 'react';
+import { MergeProps, ThemeProps } from '../../types';
+import { useThemeId } from '../../hooks/useThemeId';
+import { makeCombineRefs } from '../../utils/combineRefs';
+import { InteractiveGroupConsumer } from '../../components/InteractiveGroup/InteractiveGroupConsumer';
+import {
+  UnmanagedInteractiveGroupProvider,
+  UnmanagedInteractiveGroupProviderProps,
+} from '../../components/InteractiveGroup/UnmanagedInteractiveGroupProvider';
+import { List, ListProps } from '../../components/List';
+import { InteractiveListItem, InteractiveListItemProps } from './InteractiveListItem';
+
+type ExplicitProviderProps = Pick<
+  UnmanagedInteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
+  | 'allowReselect'
+  | 'disabled'
+  | 'initialSelected'
+  | 'items'
+  | 'maxSelect'
+  | 'minSelect'
+  | 'onItemClick'
+  | 'onItemFocus'
+  | 'onKeyDown'
+  | 'onSelect'
+  | 'onUnselect'
+  | 'parentRef'
+  | 'reducer'
+  | 'selectOnFocus'
+  | 'triggerLinks'
+>;
+
+export interface LocalUnmanagedInteractiveListProps extends ExplicitProviderProps {
+  children: React.ReactNode;
+  /** The focused state can be set outside of this component so that focus styles can be applied when, for example, a parent is focused */
+  focused?: boolean;
+  items: (Omit<InteractiveListItemProps, 'onClick'> & { selectedLabel?: string })[];
+  listComponent?: typeof List;
+  providerProps?: Omit<
+    UnmanagedInteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
+    keyof ExplicitProviderProps | 'children'
+  >;
+  unstyled?: boolean;
+}
+
+export type UnmanagedInteractiveListProps = MergeProps<ListProps<'ul'>, LocalUnmanagedInteractiveListProps> &
+  ThemeProps;
+
+function UnmanagedInteractiveListBase(
+  {
+    allowReselect,
+    children,
+    disabled,
+    focused,
+    initialSelected,
+    items,
+    listComponent,
+    maxSelect,
+    mimicSelectOnFocus,
+    minSelect,
+    onItemClick,
+    onItemFocus,
+    onKeyDown,
+    onSelect,
+    onUnselect,
+    parentRef,
+    providerProps,
+    reducer,
+    rounded,
+    selectOnFocus,
+    themeId: initThemeId,
+    transparent,
+    triggerLinks,
+    unstyled,
+    unthemed,
+    ...props
+  }: UnmanagedInteractiveListProps,
+  forwardedRef: React.ForwardedRef<HTMLUListElement>,
+): React.ReactElement {
+  const ref = useRef<HTMLUListElement>(null!);
+  const combineRefs = makeCombineRefs<HTMLUListElement>(ref, forwardedRef);
+
+  const themeId = useThemeId(initThemeId);
+
+  // this allows the consumer to passed a styled list which can react to accessible, focused, etc.
+  const ListComponent = listComponent || List;
+
+  return (
+    <UnmanagedInteractiveGroupProvider<string, HTMLUListElement, HTMLLIElement>
+      allowReselect={allowReselect}
+      disabled={disabled}
+      initialSelected={initialSelected}
+      items={items}
+      maxSelect={maxSelect}
+      minSelect={minSelect}
+      onItemClick={onItemClick}
+      onItemFocus={onItemFocus}
+      onKeyDown={onKeyDown}
+      onSelect={onSelect}
+      onUnselect={onUnselect}
+      parentRef={parentRef}
+      reducer={reducer}
+      selectOnFocus={selectOnFocus}
+      triggerLinks={triggerLinks}
+      {...providerProps}
+    >
+      <InteractiveGroupConsumer>
+        {({ focusedIndex, handleItemClick, isSelected }) =>
+          items && items.length ? (
+            <ListComponent<'ul'>
+              as="ul"
+              focused={focused}
+              inactive={disabled}
+              mimicSelectOnFocus={mimicSelectOnFocus}
+              ref={combineRefs}
+              rounded={rounded}
+              tabIndex={disabled ? -1 : 0}
+              themeId={themeId}
+              transparent={transparent}
+              unstyled={unstyled}
+              unthemed={unthemed}
+              {...(props as Omit<
+                ListProps<'ul'>,
+                | 'as'
+                | 'children'
+                | 'focused'
+                | 'inactive'
+                | 'items'
+                | 'onBlur'
+                | 'onFocus'
+                | 'ref'
+                | 'tabIndex'
+                | 'themeId'
+                | 'unstyled'
+              >)}
+            >
+              {items.map(({ id, label, disabled, ...itemProps }, index) => {
+                return (
+                  <InteractiveListItem
+                    disabled={disabled}
+                    focused={focusedIndex === index}
+                    id={id}
+                    key={id}
+                    label={label}
+                    mimicSelectOnFocus={mimicSelectOnFocus}
+                    onClick={handleItemClick}
+                    selected={isSelected(id)}
+                    transparent={transparent}
+                    unstyled={unstyled}
+                    {...(itemProps as Omit<InteractiveListItemProps, 'id' | 'label' | 'onClick'>)}
+                  />
+                );
+              })}
+            </ListComponent>
+          ) : (
+            children
+          )
+        }
+      </InteractiveGroupConsumer>
+    </UnmanagedInteractiveGroupProvider>
+  );
+}
+
+export const UnmanagedInteractiveList = React.forwardRef(
+  UnmanagedInteractiveListBase,
+) as typeof UnmanagedInteractiveListBase;
+
+UnmanagedInteractiveListBase.displayName = 'UnmanagedInteractiveListBase';
+UnmanagedInteractiveList.displayName = 'UnmanagedInteractiveList';

--- a/src/compositions/InteractiveList/UnmanagedInteractiveList.tsx
+++ b/src/compositions/InteractiveList/UnmanagedInteractiveList.tsx
@@ -14,8 +14,6 @@ type ExplicitProviderProps = Pick<
   UnmanagedInteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
   | 'allowReselect'
   | 'disabled'
-  | 'initialSelected'
-  | 'items'
   | 'maxSelect'
   | 'minSelect'
   | 'onItemClick'
@@ -33,7 +31,6 @@ export interface LocalUnmanagedInteractiveListProps extends ExplicitProviderProp
   children: React.ReactNode;
   /** The focused state can be set outside of this component so that focus styles can be applied when, for example, a parent is focused */
   focused?: boolean;
-  items: (Omit<InteractiveListItemProps, 'onClick'> & { selectedLabel?: string })[];
   listComponent?: typeof List;
   providerProps?: Omit<
     UnmanagedInteractiveGroupProviderProps<string, HTMLUListElement, HTMLLIElement>,
@@ -51,8 +48,6 @@ function UnmanagedInteractiveListBase(
     children,
     disabled,
     focused,
-    initialSelected,
-    items,
     listComponent,
     maxSelect,
     mimicSelectOnFocus,
@@ -79,6 +74,9 @@ function UnmanagedInteractiveListBase(
   const ref = useRef<HTMLUListElement>(null!);
   const combineRefs = makeCombineRefs<HTMLUListElement>(ref, forwardedRef);
 
+  const [state] = reducer;
+  const items = state.items.getAll();
+
   const themeId = useThemeId(initThemeId);
 
   // this allows the consumer to passed a styled list which can react to accessible, focused, etc.
@@ -88,8 +86,6 @@ function UnmanagedInteractiveListBase(
     <UnmanagedInteractiveGroupProvider<string, HTMLUListElement, HTMLLIElement>
       allowReselect={allowReselect}
       disabled={disabled}
-      initialSelected={initialSelected}
-      items={items}
       maxSelect={maxSelect}
       minSelect={minSelect}
       onItemClick={onItemClick}

--- a/src/compositions/InteractiveList/docs/interactiveList.mdx
+++ b/src/compositions/InteractiveList/docs/interactiveList.mdx
@@ -9,7 +9,7 @@ import { Playground, Props } from 'docz';
 import { InteractiveGroupItem, InteractiveGroupConsumer } from 'components/InteractiveGroup';
 import { PageTitle } from 'docs/helpers/PageTitle';
 import { ThemeWrapper } from 'docs/helpers/ThemeWrapper';
-import { InteractiveList } from '../index';
+import { InteractiveList, UnmanagedInteractiveList } from '../index';
 import { options, navigationOptions } from './helpers/options';
 import scrollbar from 'styles/common/Scrollbar.module.css';
 
@@ -329,3 +329,7 @@ _Note that the links will cause the page to reload so the state will appear unch
 ### InteractiveList
 
 <Props of={InteractiveList} />
+
+### UnmanagedInteractiveList
+
+<Props of={UnmanagedInteractiveList} />

--- a/src/compositions/InteractiveList/docs/interactiveList.mdx
+++ b/src/compositions/InteractiveList/docs/interactiveList.mdx
@@ -28,7 +28,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        initialSelected="violet-red"
+        initialSelected={['violet-red']}
         items={options}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}
@@ -53,7 +53,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        initialSelected="red"
+        initialSelected={['red']}
         items={options}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}
@@ -79,7 +79,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        initialSelected="red"
+        initialSelected={['red']}
         items={options}
         mimicSelectOnFocus
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
@@ -100,7 +100,6 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
   <ThemeWrapper withThemeId>
     {({ themeId }) => (
       <InteractiveList
-        allowMultiSelect
         className={cx(
           scrollbar['scrollbar--small'],
           scrollbar['scrollbar--primary'],
@@ -108,6 +107,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         )}
         initialSelected={['violet-red']}
         items={options}
+        maxSelect={-1}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}
         onUnselect={(event, { id }) => console.log('unselect', id)}
@@ -120,7 +120,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
   </ThemeWrapper>
 </Playground>
 
-## Disable unselect
+## Allow unselect
 
 <Playground>
   <ThemeWrapper withThemeId>
@@ -131,9 +131,9 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        disableUnselect
-        initialSelected="red"
+        initialSelected={['red']}
         items={options}
+        minSelect={0}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}
         onUnselect={(event, { id }) => console.log('unselect', id)}
@@ -158,9 +158,9 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        disableUnselect
-        initialSelected="red"
+        initialSelected={['red']}
         items={options}
+        minSelect={1}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}
         onUnselect={(event, { id }) => console.log('unselect', id)}
@@ -239,7 +239,7 @@ _Note that the links will cause the page to reload so the state will appear unch
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        initialSelected="red"
+        initialSelected={['red']}
         items={[
           {
             id: 'first',
@@ -297,7 +297,7 @@ _Note that the links will cause the page to reload so the state will appear unch
           scrollbar['scrollbar--primary'],
           scrollbar[`scrollbar--${themeId}`],
         )}
-        initialSelected="violet-red"
+        initialSelected={['violet-red']}
         items={navigationOptions}
         onItemFocus={(event, { id, index }) => console.log('focus', { id, index })}
         onSelect={(event, { id, index }) => console.log('select', { id, index })}

--- a/src/compositions/InteractiveList/index.ts
+++ b/src/compositions/InteractiveList/index.ts
@@ -1,2 +1,3 @@
 export * from './InteractiveList';
 export * from './InteractiveListItem';
+export * from './UnmanagedInteractiveList';

--- a/src/compositions/Navigation/InnerNavigation.tsx
+++ b/src/compositions/Navigation/InnerNavigation.tsx
@@ -28,7 +28,7 @@ export interface InnerNavigationProps extends React.HTMLAttributes<HTMLElement>,
   items: Array<
     Omit<NavigationItemProps, 'children' | 'componentId' | 'key' | 'onClick' | 'variant' | 'vertical'> & {
       label: React.ReactNode;
-      triggerOnly?: InteractiveGroupItemType['triggerOnly'];
+      triggerOnly?: InteractiveGroupItemType<string>['triggerOnly'];
     }
   >;
   selectedId: string;
@@ -67,8 +67,8 @@ export const InnerNavigation = React.forwardRef<HTMLElement, InnerNavigationProp
     const { componentId } = useComponentId();
     const { isInitialized } = useInitializer();
 
-    const { focusedIndex, handleItemClick, setSelected } = useContext<
-      InteractiveGroupContextValue<HTMLElement, HTMLDivElement>
+    const { focusedIndex, handleItemClick, selectId } = useContext<
+      InteractiveGroupContextValue<string, HTMLElement, HTMLDivElement>
     >(InteractiveGroupContext);
 
     const combineRefs = makeCombineRefs(ref, forwardedRef);
@@ -92,8 +92,8 @@ export const InnerNavigation = React.forwardRef<HTMLElement, InnerNavigationProp
 
     // update the reducer from the selected ID passed; skip on the first run
     useEffect(() => {
-      isInitialized('selectedId') && setSelected(selectedId);
-    }, [setSelected, selectedId, isInitialized]);
+      isInitialized('selectedId') && selectId(selectedId);
+    }, [selectedId, isInitialized, selectId]);
 
     // update dummy state to force redraw; use a string because an array or object would trigger redraw every time
     const handleWindowResize = useCallback(() => {

--- a/src/compositions/Navigation/Navigation.tsx
+++ b/src/compositions/Navigation/Navigation.tsx
@@ -46,13 +46,13 @@ export function Navigation({
 }: NavigationProps): React.ReactElement {
   return (
     <ListRegistryProvider>
-      <InteractiveGroupProvider<HTMLElement, HTMLDivElement>
+      <InteractiveGroupProvider<string, HTMLElement, HTMLDivElement>
         allowReselect
-        disableUnselect
+        maxSelect={1}
+        minSelect={1}
         onSelect={onSelect}
         items={items}
         triggerLinks={triggerLinks}
-        {...props}
       >
         {ref => (
           <InnerNavigation

--- a/src/compositions/Tabs/TabList.tsx
+++ b/src/compositions/Tabs/TabList.tsx
@@ -64,10 +64,11 @@ function TabListBase(
   const themeId = useThemeId(initThemeId);
   const variant = contrast ? 'contrast' : initVariant;
 
-  const { handleItemClick, focusedIndex, selectedId } = useContext<
-    InteractiveGroupContextValue<HTMLDivElement, HTMLDivElement>
+  const { handleItemClick, focusedIndex, selectedIds } = useContext<
+    InteractiveGroupContextValue<string, HTMLDivElement, HTMLDivElement>
   >(InteractiveGroupContext);
 
+  const selectedId = selectedIds?.[0];
   const combineRefs = makeCombineRefs(ref, forwardedRef);
 
   const handleBlurMemoized = useCallback(

--- a/src/compositions/Tabs/TabPanelGroup.tsx
+++ b/src/compositions/Tabs/TabPanelGroup.tsx
@@ -46,9 +46,12 @@ export function TabPanelGroup({
   const themeId = useThemeId(initThemeId);
   const variant = contrast ? 'contrast' : initVariant;
 
-  const { selectedId } = useContext<InteractiveGroupContextValue<HTMLDivElement, HTMLDivElement>>(
+  const { selectedIds } = useContext<InteractiveGroupContextValue<string, HTMLDivElement, HTMLDivElement>>(
     InteractiveGroupContext,
   );
+
+  // because the interactive group always uses an array for selected ids
+  const selectedId = selectedIds?.[0];
 
   return (
     <div

--- a/src/compositions/Tabs/Tabs.tsx
+++ b/src/compositions/Tabs/Tabs.tsx
@@ -21,16 +21,18 @@ export type TabsRenderChildren = (
   },
 ) => React.ReactElement<HTMLDivElement>;
 
-export interface TabsProps extends ThemeProps {
-  allowUnselect?: boolean;
+export interface TabsProps
+  extends Omit<
+      InteractiveGroupProviderProps<string, HTMLDivElement, HTMLDivElement>,
+      'children' | 'items' | 'maxSelect'
+    >,
+    ThemeProps {
   children?: TabsRenderChildren;
   className?: string;
   contrast?: boolean;
   fullWidth?: boolean;
-  initialSelected?: string;
   items: Array<TabListProps['items'][0] & TabPanelGroupProps['items'][0]>;
   listProps?: React.HTMLAttributes<HTMLDivElement>;
-  onSelect?: InteractiveGroupProviderProps['onSelect'];
   panelGroupProps?: React.HTMLAttributes<HTMLDivElement>;
   style?: React.CSSProperties;
   unstyled?: boolean;
@@ -39,7 +41,6 @@ export interface TabsProps extends ThemeProps {
 }
 
 export function Tabs({
-  allowUnselect,
   children,
   className,
   contrast,
@@ -47,6 +48,7 @@ export function Tabs({
   initialSelected,
   items,
   listProps = {},
+  minSelect,
   onSelect,
   panelGroupProps = {},
   style,
@@ -65,11 +67,12 @@ export function Tabs({
 
   return (
     <ListRegistryProvider>
-      <InteractiveGroupProvider<HTMLDivElement, HTMLDivElement>
-        disableUnselect={!allowUnselect}
+      <InteractiveGroupProvider<string, HTMLDivElement, HTMLDivElement>
         onSelect={onSelect}
+        maxSelect={1}
+        minSelect={minSelect}
         items={items}
-        initialSelected={initialSelected || (items[0] && items[0].id)}
+        initialSelected={initialSelected || (items[0] && [items[0].id])}
         {...props}
       >
         {

--- a/src/compositions/Tabs/docs/tabs.mdx
+++ b/src/compositions/Tabs/docs/tabs.mdx
@@ -100,7 +100,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 <Playground>
   <ThemeWrapper>
     <Tabs
-      initialSelected="second"
+      initialSelected={['second']}
       onSelect={(event, id) => console.log(id)}
       items={[
         {
@@ -191,7 +191,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
         render={({ id }) => (
           <Rhythm key={id} my={1}>
             <ColoredTabs
-              initialSelected="third"
+              initialSelected={['third']}
               colorId={id}
               vertical
               onSelect={(event, id) => console.log(id)}
@@ -215,7 +215,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
   <ThemeWrapper>
     <Tabs
       unstyled
-      initialSelected="second"
+      initialSelected={['second']}
       style={{ outline: 'none' }}
       onSelect={(event, id) => console.log(id)}
       items={[
@@ -326,7 +326,7 @@ Keyboard navigation is available for this component. Navigate with `Up`, `Down`,
 <Playground>
   <ThemeWrapper>
     <Tabs
-      allowUnselect
+      minSelect={0}
       onSelect={(event, id) => console.log(id)}
       items={[
         { id: 'first', label: 'First', content: 'First panel' },

--- a/src/docs/playground.mdx
+++ b/src/docs/playground.mdx
@@ -559,7 +559,7 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
           <Dropdown
             arrowIconSize={12}
             dropdownContent={DropdownContent}
-            initialSelected={options[0]}
+            initialSelected={[options[0]]}
             label="Super awesome dropdown"
             layout="raised"
             listVariant="divided"
@@ -646,7 +646,7 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
           <Dropdown
             arrowIconSize={12}
             dropdownContent={DropdownContent}
-            initialSelected={options[0]}
+            initialSelected={[options[0]]}
             inputVariant="outline"
             layout="raised"
             listVariant="divided"
@@ -685,7 +685,7 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
         <Card hoverable raised full style={{ maxWidth: '300px' }}>
           <ColoredTabs
             colorId="P50"
-            initialSelected="check"
+            initialSelected={['check']}
             vertical
             onSelect={(event, id) => console.log(id)}
             items={[
@@ -738,7 +738,7 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
                 label: <CheckIcon style={{ display: 'block' }} />,
                 content: (
                   <InteractiveList
-                    initialSelected={4}
+                    initialSelected={[4]}
                     selectOnFocus
                     variant="divided"
                     items={[{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }].map(option => ({

--- a/src/docs/playground.mdx
+++ b/src/docs/playground.mdx
@@ -22,8 +22,6 @@ import {
   ColoredPaper,
   ColoredTabs,
   Divider,
-  Dropdown,
-  DropdownContent,
   DropoverContent,
   DropoverInputLabel,
   Flex,
@@ -39,6 +37,7 @@ import {
   List,
   ListItem,
   MainPanel,
+  ManagedDropdown,
   Modal,
   ModalConsumer,
   ModalBody,
@@ -556,9 +555,8 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
       }));
       return (
         <div style={{ width: '400px', maxWidth: '100%', height: '200px' }}>
-          <Dropdown
+          <ManagedDropdown
             arrowIconSize={12}
-            dropdownContent={DropdownContent}
             initialSelected={[options[0]]}
             label="Super awesome dropdown"
             layout="raised"
@@ -643,9 +641,8 @@ import scrollbar from 'styles/common/Scrollbar.module.css';
       }));
       return (
         <div style={{ width: '300px', maxWidth: '100%', height: '300px' }}>
-          <Dropdown
+          <ManagedDropdown
             arrowIconSize={12}
-            dropdownContent={DropdownContent}
             initialSelected={[options[0]]}
             inputVariant="outline"
             layout="raised"


### PR DESCRIPTION
* Refactored `Dropdown` for multi-select, added "highlight" styles to selected item(s).
* Created managed and unmanaged interactive groups and interactive lists so that the reducer tracking the state can be passed in, allowing parent components to access to the state.
* Refactored `Accordion`, `Navigation`, `Tabs` to use new managed interactive groups.

![Screenshot from 2021-05-16 11-49-07](https://user-images.githubusercontent.com/196027/118408937-c8515b00-b63c-11eb-8a7f-109ccd4c7c02.png)
