### PR TITLE
:label: refactor(major): updated most children types

### DIFF
--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from '../../src/context/Theme/ThemeProvider';
 import { getThemeId } from '../addons/theme/utils';
 
 type DocsContainerProps = {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   context: BaseContainerProps['context'];
 };
 

--- a/__mocks__/AsType.mock.tsx
+++ b/__mocks__/AsType.mock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface AsTypeAProps extends React.HTMLAttributes<HTMLAnchorElement> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 }
 
 export function AsTypeA({ children, ...props }: AsTypeAProps): React.ReactElement<AsTypeAProps, 'a'> {
@@ -9,7 +9,7 @@ export function AsTypeA({ children, ...props }: AsTypeAProps): React.ReactElemen
 }
 
 export interface AsTypeDivProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 }
 
 export function AsTypeDiv({ children, ...props }: AsTypeDivProps): React.ReactElement<AsTypeDivProps, 'div'> {
@@ -17,7 +17,7 @@ export function AsTypeDiv({ children, ...props }: AsTypeDivProps): React.ReactEl
 }
 
 export interface AsTypePProps extends React.HTMLAttributes<HTMLParagraphElement> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 }
 
 export function AsTypeP({ children, ...props }: AsTypePProps): React.ReactElement<AsTypePProps, 'p'> {
@@ -25,7 +25,7 @@ export function AsTypeP({ children, ...props }: AsTypePProps): React.ReactElemen
 }
 
 export interface AsTypeUlProps extends React.HTMLAttributes<HTMLUListElement> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 }
 
 export function AsTypeUl({ children, ...props }: AsTypeUlProps): React.ReactElement<AsTypeUlProps, 'ul'> {
@@ -33,7 +33,7 @@ export function AsTypeUl({ children, ...props }: AsTypeUlProps): React.ReactElem
 }
 
 export interface AsTypeLiProps extends React.HTMLAttributes<HTMLLIElement> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 }
 
 export function AsTypeLi({ children, ...props }: AsTypeLiProps): React.ReactElement<AsTypeLiProps, 'li'> {

--- a/__tests__/components/Paper/Paper.test.tsx
+++ b/__tests__/components/Paper/Paper.test.tsx
@@ -10,6 +10,16 @@ describe('<Paper />', () => {
     expect(getByText('Hello world')).toBeTruthy();
   });
 
+  it('should render a paper with multiple children', () => {
+    const { getAllByText } = render(
+      <Paper>
+        <div>Hello world</div>
+        <div>Hello world</div>
+      </Paper>,
+    );
+    expect(getAllByText('Hello world').length).toBe(2);
+  });
+
   it('should focus scrollable paper on tab', () => {
     const { container, getByTestId } = render(
       <Paper scrollable data-testid="paper">

--- a/__tests__/compositions/Popover/InlinePopover.test.tsx
+++ b/__tests__/compositions/Popover/InlinePopover.test.tsx
@@ -5,7 +5,7 @@ import { render } from '../../utils';
 describe('<InlinePopover />', () => {
   it('should render a popover', () => {
     const { getByText } = render(
-      <InlinePopover focusable permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300}>
+      <InlinePopover permanent height={80} position="top-center" toggler={<TimesIcon scale="3xlarge" />} width={300}>
         <div>Hello world</div>
       </InlinePopover>,
     );

--- a/__tests__/compositions/Popover/InlinePopover.test.tsx
+++ b/__tests__/compositions/Popover/InlinePopover.test.tsx
@@ -32,4 +32,31 @@ describe('<InlinePopover />', () => {
     expect(getByText('Hello world')).toBeTruthy();
     expect(getByText('bottom-right')).toBeTruthy();
   });
+
+  it('should render a popover and generate a position', () => {
+    const { getByText } = render(
+      <InlinePopover
+        permanent
+        height={80}
+        layout="vertical"
+        renderChildren={({ position }) => <div>{position}</div>}
+        toggler={<TimesIcon scale="3xlarge" />}
+        width={300}
+      />,
+    );
+    expect(getByText('bottom-right')).toBeTruthy();
+  });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <InlinePopover permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Popover/PortalPopover.test.tsx
+++ b/__tests__/compositions/Popover/PortalPopover.test.tsx
@@ -5,7 +5,7 @@ import { render } from '../../utils';
 describe('<PortalPopover />', () => {
   it('should render a popover', () => {
     const { getByText } = render(
-      <PortalPopover focusable permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300}>
+      <PortalPopover permanent height={80} position="top-center" toggler={<TimesIcon scale="3xlarge" />} width={300}>
         <div>Hello world</div>
       </PortalPopover>,
     );

--- a/__tests__/compositions/Popover/PortalPopover.test.tsx
+++ b/__tests__/compositions/Popover/PortalPopover.test.tsx
@@ -32,4 +32,31 @@ describe('<PortalPopover />', () => {
     expect(getByText('Hello world')).toBeTruthy();
     expect(getByText('bottom-right')).toBeTruthy();
   });
+
+  it('should render a popover and generate a position', () => {
+    const { getByText } = render(
+      <PortalPopover
+        permanent
+        height={80}
+        layout="vertical"
+        renderChildren={({ position }) => <div>{position}</div>}
+        toggler={<TimesIcon scale="3xlarge" />}
+        width={300}
+      />,
+    );
+    expect(getByText('bottom-right')).toBeTruthy();
+  });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <PortalPopover permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Tooltip/InlineTextTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/InlineTextTooltip.test.tsx
@@ -17,4 +17,17 @@ describe('<InlineTextTooltip />', () => {
     );
     expect(getByText('Hello world')).toBeTruthy();
   });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <InlineTextTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Tooltip/InlineTextTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/InlineTextTooltip.test.tsx
@@ -5,7 +5,13 @@ import { render } from '../../utils';
 describe('<InlineTextTooltip />', () => {
   it('should render a tooltip', () => {
     const { getByText } = render(
-      <InlineTextTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300}>
+      <InlineTextTooltip
+        permanent
+        height={80}
+        position="top-center"
+        toggler={<TimesIcon scale="3xlarge" />}
+        width={300}
+      >
         Hello world
       </InlineTextTooltip>,
     );

--- a/__tests__/compositions/Tooltip/InlineTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/InlineTooltip.test.tsx
@@ -5,7 +5,14 @@ import { render } from '../../utils';
 describe('<InlineTooltip />', () => {
   it('should render a tooltip', () => {
     const { getByText } = render(
-      <InlineTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} triangleColor="#fff" width={300}>
+      <InlineTooltip
+        permanent
+        height={80}
+        position="top-center"
+        toggler={<TimesIcon scale="3xlarge" />}
+        triangleColor="#fff"
+        width={300}
+      >
         <div>Hello world</div>
       </InlineTooltip>,
     );

--- a/__tests__/compositions/Tooltip/InlineTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/InlineTooltip.test.tsx
@@ -39,4 +39,32 @@ describe('<InlineTooltip />', () => {
     expect(getByText('Hello world')).toBeTruthy();
     expect(getByText('bottom-right')).toBeTruthy();
   });
+
+  it('should render a popover and generate a position', () => {
+    const { getByText } = render(
+      <InlineTooltip
+        permanent
+        height={80}
+        layout="vertical"
+        renderChildren={({ position }) => <div>{position}</div>}
+        toggler={<TimesIcon scale="3xlarge" />}
+        triangleColor="#fff"
+        width={300}
+      />,
+    );
+    expect(getByText('bottom-right')).toBeTruthy();
+  });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <InlineTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Tooltip/PortalTextTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/PortalTextTooltip.test.tsx
@@ -17,4 +17,17 @@ describe('<PortalTextTooltip />', () => {
     );
     expect(getByText('Hello world')).toBeTruthy();
   });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <PortalTextTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Tooltip/PortalTextTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/PortalTextTooltip.test.tsx
@@ -5,7 +5,13 @@ import { render } from '../../utils';
 describe('<PortalTextTooltip />', () => {
   it('should render a tooltip', () => {
     const { getByText } = render(
-      <PortalTextTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300}>
+      <PortalTextTooltip
+        permanent
+        height={80}
+        position="top-center"
+        toggler={<TimesIcon scale="3xlarge" />}
+        width={300}
+      >
         Hello world
       </PortalTextTooltip>,
     );

--- a/__tests__/compositions/Tooltip/PortalTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/PortalTooltip.test.tsx
@@ -39,4 +39,32 @@ describe('<PortalTooltip />', () => {
     expect(getByText('Hello world')).toBeTruthy();
     expect(getByText('bottom-right')).toBeTruthy();
   });
+
+  it('should render a popover and generate a position', () => {
+    const { getByText } = render(
+      <PortalTooltip
+        permanent
+        height={80}
+        layout="vertical"
+        renderChildren={({ position }) => <div>{position}</div>}
+        toggler={<TimesIcon scale="3xlarge" />}
+        triangleColor="#fff"
+        width={300}
+      />,
+    );
+    expect(getByText('bottom-right')).toBeTruthy();
+  });
+
+  it('should error without children', () => {
+    const consoleWarnMock = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      render(
+        /* @ts-ignore */
+        <PortalTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} width={300} />,
+      ),
+    ).toThrow();
+
+    consoleWarnMock.mockRestore();
+  });
 });

--- a/__tests__/compositions/Tooltip/PortalTooltip.test.tsx
+++ b/__tests__/compositions/Tooltip/PortalTooltip.test.tsx
@@ -5,7 +5,14 @@ import { render } from '../../utils';
 describe('<PortalTooltip />', () => {
   it('should render a tooltip', () => {
     const { getByText } = render(
-      <PortalTooltip permanent height={80} toggler={<TimesIcon scale="3xlarge" />} triangleColor="#fff" width={300}>
+      <PortalTooltip
+        permanent
+        height={80}
+        position="top-center"
+        toggler={<TimesIcon scale="3xlarge" />}
+        triangleColor="#fff"
+        width={300}
+      >
         <div>Hello world</div>
       </PortalTooltip>,
     );

--- a/scripts/scaffold-component.js
+++ b/scripts/scaffold-component.js
@@ -61,7 +61,7 @@ import styles from './styles/${component}.module.css';
 
 export type ${component}Props = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     style?: React.CSSProperties;
   };

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -8,7 +8,7 @@ import styles from './styles/Badge.module.css';
 export type BadgeShape = 'marker' | 'point' | 'count' | 'label';
 
 export type LocalBadgeProps = ThemeProps & {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   color?: SemanticColor;
   /** Adds a 1px outline to the badge to make it stand out */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -9,7 +9,7 @@ export type LocalButtonProps = ThemeProps & {
   /** Manually apply the active styles; this does not affect :active */
   active?: boolean;
   align?: ButtonAlignment;
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   color?: ButtonColor;
   disabled?: boolean;

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -12,7 +12,7 @@ export type ButtonGroupAlignment = 'left' | 'center' | 'right';
 
 export type ButtonGroupItem = {
   id: string;
-  label: React.ReactNode | ((selected: boolean) => JSX.Element);
+  label: React.ReactChild | React.ReactFragment | ((selected: boolean) => JSX.Element);
   selected?: boolean;
 } & Omit<ButtonProps, 'children' | 'id' | 'key' | 'size' | 'value'>;
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Card.module.css';
 export type CardProps = React.HTMLAttributes<HTMLDivElement> &
   Omit<ThemeProps, 'contrast'> & {
     bordered?: boolean;
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     full?: boolean;
     hoverable?: boolean;

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -7,7 +7,7 @@ export type FlexProps = React.HTMLAttributes<HTMLDivElement> & {
   alignContent?: 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between' | 'stretch';
   alignSelf?: 'baseline' | 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between' | 'stretch';
   /** The children are optional so that this component can be passed as empty and then cloned */
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   direction?: 'column' | 'row';
   /** This sets the style to `flex: 1` */

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Footer.module.css';
 export type FooterProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
     bordered?: boolean | 'pseudo';
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     full?: boolean;
     style?: React.CSSProperties;

--- a/src/components/Form/Checkbox/Checkbox.tsx
+++ b/src/components/Form/Checkbox/Checkbox.tsx
@@ -25,7 +25,7 @@ export type CheckboxSize =
 
 export type LocalCheckboxProps<V extends CheckboxValue = string> = ThemeProps & {
   checked?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment;
   className?: string;
   disabled?: boolean;
   /** Sets the width to 100% */

--- a/src/components/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/components/Form/Checkbox/CheckboxGroup.tsx
@@ -18,7 +18,7 @@ export type CheckboxGroupItem<V extends CheckboxValue = string> = Omit<
 
 export type LocalCheckboxGroupProps<V extends CheckboxValue = string> = Omit<ThemeProps, 'unthemed'> & {
   className?: string;
-  legend?: React.ReactNode;
+  legend?: React.ReactChild | React.ReactFragment | null;
   layout: 'stacked' | 'inline';
   onChange: (event: React.ChangeEvent<HTMLInputElement>, values: readonly V[]) => void;
   checkboxes: readonly CheckboxGroupItem<V>[];

--- a/src/components/Form/Fieldset/Fieldset.tsx
+++ b/src/components/Form/Fieldset/Fieldset.tsx
@@ -8,7 +8,7 @@ import styles from './styles/Fieldset.module.css';
 export type LocalFieldsetProps = Omit<ThemeProps, 'unthemed'> & {
   children: React.ReactElement | string;
   className?: string;
-  legend?: React.ReactNode;
+  legend?: React.ReactChild | React.ReactFragment | null;
   style?: React.CSSProperties;
 };
 

--- a/src/components/Form/Formbox/FormboxContainer.tsx
+++ b/src/components/Form/Formbox/FormboxContainer.tsx
@@ -9,7 +9,7 @@ import { FormboxContainerElementType, FormboxInputElementType, FormboxSize, Form
 export type LocalFormboxContainerProps = ThemeProps & {
   /** Whether the formbox input was auto-filled (see useAutoFilled hook) */
   autoFilled?: boolean;
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   centered?: boolean;
   className?: string;
   disabled?: boolean;

--- a/src/components/Form/Label/Label.tsx
+++ b/src/components/Form/Label/Label.tsx
@@ -5,7 +5,7 @@ import { useThemeId } from '../../../context/Theme';
 import styles from './styles/Label.module.css';
 
 export type LocalLabelProps = ThemeProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   disabled?: boolean;
   /** Manually apply the focus styles; this does not affect focus */

--- a/src/components/Form/Notification/Notification.tsx
+++ b/src/components/Form/Notification/Notification.tsx
@@ -6,7 +6,7 @@ import styles from './styles/Notification.module.css';
 
 export type NotificationProps = React.HTMLAttributes<HTMLDivElement> &
   Omit<ThemeProps, 'unthemed'> & {
-    children: React.ReactNode;
+    children?: React.ReactChild | React.ReactFragment;
     className?: string;
     color?: SemanticColor;
     /** Add a divider above the notification */

--- a/src/components/Form/Radio/Radio.tsx
+++ b/src/components/Form/Radio/Radio.tsx
@@ -25,7 +25,7 @@ export type RadioSize =
 
 export type LocalRadioProps<V extends RadioValue = string> = ThemeProps & {
   checked?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment;
   className?: string;
   disabled?: boolean;
   /** Sets the width to 100% */

--- a/src/components/Form/Radio/RadioGroup.tsx
+++ b/src/components/Form/Radio/RadioGroup.tsx
@@ -18,7 +18,7 @@ export type RadioGroupItem<V extends RadioValue = string> = Omit<
 
 export type LocalRadioGroupProps<V extends RadioValue = string> = Omit<ThemeProps, 'unthemed'> & {
   className?: string;
-  legend?: React.ReactNode;
+  legend?: React.ReactChild | React.ReactFragment | null;
   layout: 'stacked' | 'inline';
   name: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>, value: V) => void;

--- a/src/components/Form/Slider/MultiColorSliderTrack.tsx
+++ b/src/components/Form/Slider/MultiColorSliderTrack.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { MergeElementPropsWithoutRef } from '../../../types';
 
 export type LocalMultiColorSliderTrackProps = {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className: string;
   colors: readonly string[];
   sliderWidth?: number;

--- a/src/components/Form/Slider/Slider.tsx
+++ b/src/components/Form/Slider/Slider.tsx
@@ -20,11 +20,11 @@ type SliderEvent =
 
 export type LocalSliderProps = Omit<ThemeProps, 'unthemed'> & {
   /** This is used to populate the label value */
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   disabled?: boolean;
   /** Applies formatting to the value before displaying it */
-  formatValue?: (value?: number) => React.ReactNode;
+  formatValue?: (value?: number) => React.ReactChild | React.ReactFragment | undefined;
   id?: string;
   max?: number;
   min?: number;
@@ -238,6 +238,8 @@ export function SliderBase(
     value: { width: sliderWidth },
   } = useSizeListeners<HTMLLabelElement>({ propsToMeasure });
 
+  const labelValue = formatValue ? formatValue(getValue()) : getValue();
+
   return (
     <label
       className={cx(
@@ -325,7 +327,7 @@ export function SliderBase(
         {...props}
       />
 
-      {valuePosition && (
+      {valuePosition && labelValue !== undefined && (
         <Label<'div'>
           noWrap
           as="div"
@@ -334,7 +336,7 @@ export function SliderBase(
           strength="standard"
           themeId={themeId}
         >
-          {formatValue ? formatValue(getValue()) : getValue()}
+          {labelValue}
         </Label>
       )}
     </label>

--- a/src/components/Form/Toggle/Toggle.tsx
+++ b/src/components/Form/Toggle/Toggle.tsx
@@ -10,7 +10,7 @@ import styles from './styles/Toggle.module.css';
 
 export type LocalToggleProps = ThemeProps & {
   checked?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment;
   className?: string;
   disabled?: boolean;
   full?: boolean;

--- a/src/components/Form/docs/helpers/FormDemo.tsx
+++ b/src/components/Form/docs/helpers/FormDemo.tsx
@@ -91,7 +91,7 @@ type FormDemoChildrenProps = Omit<UseFormResponse<FormDemoValues>, 'handleSubmit
 };
 
 type FormDemoProps = {
-  children: (props: FormDemoChildrenProps) => React.ReactNode;
+  children: (props: FormDemoChildrenProps) => React.ReactChild | React.ReactFragment;
   contrast?: boolean;
   style?: React.CSSProperties;
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Header.module.css';
 export type HeaderProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
     bordered?: boolean | 'pseudo';
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     full?: boolean;
     style?: React.CSSProperties;

--- a/src/components/IconText/IconText.tsx
+++ b/src/components/IconText/IconText.tsx
@@ -9,7 +9,7 @@ export type IconTextProps = React.HTMLAttributes<HTMLDivElement> & {
   inline?: boolean;
   reverse?: boolean;
   style?: React.CSSProperties;
-  text: React.ReactNode;
+  text: React.ReactChild | React.ReactFragment;
   textClassName?: string;
 };
 

--- a/src/components/InteractiveGroup/types.ts
+++ b/src/components/InteractiveGroup/types.ts
@@ -3,7 +3,7 @@ export type InteractiveGroupItemId = string | number;
 export type InteractiveGroupItemType<T extends InteractiveGroupItemId = string> = {
   disabled?: boolean;
   id: T;
-  label: React.ReactNode;
+  label: React.ReactChild | React.ReactFragment;
   triggerOnly?: () => void;
 };
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -8,7 +8,7 @@ export type LinkProps = React.HTMLAttributes<HTMLAnchorElement> &
   ThemeProps & {
     /** Display as a block level element rather than inline */
     block?: boolean;
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     href?: string;
     rel?: string;

--- a/src/components/Link/LinkContainer.tsx
+++ b/src/components/Link/LinkContainer.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Link.module.css';
 export type LinkContainerElementType = keyof JSX.IntrinsicElements;
 
 export type LocalLinkContainerProps = ThemeProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   style?: React.CSSProperties;
   target?: string;

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -13,7 +13,7 @@ export const listItemElementMap: ListItemElementMap = {
 };
 
 export type LocalListProps = ThemeProps & {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   color?: 'primary' | 'neutral';
   /** The focused flag adds an outline to a focused list in accessibility mode */

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -5,7 +5,7 @@ import styles from './styles/List.module.css';
 import { ListItemElementType } from './types';
 
 export type LocalListItemProps = ThemeProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   disabled?: boolean;
   flush?: boolean;

--- a/src/components/Panels/MainPanel/MainPanel.tsx
+++ b/src/components/Panels/MainPanel/MainPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './styles/MainPanel.module.css';
 
 export type MainPanelProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   style?: React.CSSProperties;
 };

--- a/src/components/Panels/PanelContainer/PanelContainer.tsx
+++ b/src/components/Panels/PanelContainer/PanelContainer.tsx
@@ -6,7 +6,7 @@ import styles from './styles/PanelContainer.module.css';
 export type PanelContainerProps = React.HTMLAttributes<HTMLDivElement> & {
   /** Use absolute positioning and top,right,bottom,left of 0 to fill the parent */
   absolute?: boolean;
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   /** Set the width and height to 100% */
   full?: boolean;

--- a/src/components/Panels/SidePanel/PermanentSidePanel.tsx
+++ b/src/components/Panels/SidePanel/PermanentSidePanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './styles/SidePanel.module.css';
 
 export type PermanentSidePanelProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   fixed?: boolean;
   position: 'left' | 'right';

--- a/src/components/Panels/SidePanel/SidePanel.tsx
+++ b/src/components/Panels/SidePanel/SidePanel.tsx
@@ -11,7 +11,7 @@ export type SidePanelProps = Pick<
 > &
   Partial<Pick<UsePanelCollapserProps, 'easing' | 'unit' | 'transition'>> &
   React.HTMLAttributes<HTMLDivElement> & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     /** The open and close animation duration */
     duration?: number;

--- a/src/components/Panels/StackPanel/PermanentStackPanel.tsx
+++ b/src/components/Panels/StackPanel/PermanentStackPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './styles/StackPanel.module.css';
 
 export type PermanentStackPanelProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   fixed?: boolean;
   height?: number;

--- a/src/components/Panels/StackPanel/StackPanel.tsx
+++ b/src/components/Panels/StackPanel/StackPanel.tsx
@@ -11,7 +11,7 @@ export type StackPanelProps = Pick<
 > &
   Partial<Pick<UsePanelCollapserProps, 'easing' | 'unit' | 'transition'>> &
   React.HTMLAttributes<HTMLDivElement> & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     /** The open and close animation duration */
     duration?: number;

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -8,7 +8,7 @@ import styles from './styles/Paper.module.css';
 export type PaperProps = React.HTMLAttributes<HTMLDivElement> &
   Omit<ThemeProps, 'contrast'> & {
     bordered?: boolean;
-    children: React.ReactChild | React.ReactChild[];
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     color?: StateColor | SequentialVariant | AccentColor | 'contrast' | 'transparent' | 'extreme';
     /** This is used when the paper is contained within a relative element and should fill it */

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -8,7 +8,7 @@ export type PortalProps = Pick<UseAbsoluteCoordsProps, 'centered' | 'offset' | '
   React.HTMLAttributes<HTMLDivElement> & {
     /** This will render a hidden portal; otherwise hidden portals are not rendered */
     alwaysRender?: boolean;
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment | null | undefined;
     className?: string;
     /** This is the element that the portal will be rendered inside */
     container?: HTMLElement;

--- a/src/components/Position/Position.tsx
+++ b/src/components/Position/Position.tsx
@@ -5,7 +5,7 @@ import { lowerCamelize } from '../../utils/case';
 import styles from './styles/Position.module.css';
 
 export type PositionProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   fixed?: boolean;
   location: AnyPosition | 'center';

--- a/src/components/Shade/Shade.tsx
+++ b/src/components/Shade/Shade.tsx
@@ -9,7 +9,7 @@ export type ShadeProps = React.HTMLAttributes<HTMLDivElement> &
     actionable?: boolean;
     /** Manually apply the active styles; this does not affect :active */
     active?: boolean;
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     color?: SemanticColor;
     /** Manually apply the focus styles; this does not affect :focus */

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -14,7 +14,7 @@ export type LocalTagProps = ThemeProps & {
   actionable?: boolean;
   /** Manually apply the active styles; this does not affect :active */
   active?: boolean;
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   /** This will remove all padding from the tag */
   flush?: boolean;

--- a/src/components/Tag/TagGroup.tsx
+++ b/src/components/Tag/TagGroup.tsx
@@ -13,7 +13,7 @@ export type TagGroupItem = {
 export type TagGroupProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
     actionable?: boolean;
-    children?: React.ReactNode;
+    children?: React.ReactChild | React.ReactFragment | null;
     className?: string;
     shape?: TagShape;
     size?: TagSize;

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -40,7 +40,7 @@ export type TypographyVariants =
 export type LocalTypographyProps = {
   align?: HorizontalPosition | 'center';
   /** The children are optional so that this component can be passed as empty and then cloned */
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   color?: SequentialVariant | AccentColor | StateColor | 'neutral' | 'contrast';
   fullWidth?: boolean;

--- a/src/compositions/Accordion/AccordionContainer.tsx
+++ b/src/compositions/Accordion/AccordionContainer.tsx
@@ -7,7 +7,7 @@ import styles from './styles/Accordion.module.css';
 
 export type AccordionContainerProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     focused?: boolean;
     orientation?: Orientation;

--- a/src/compositions/Accordion/AccordionContent.tsx
+++ b/src/compositions/Accordion/AccordionContent.tsx
@@ -15,7 +15,7 @@ export type AccordionContentProps = React.HTMLAttributes<HTMLDivElement> &
   Pick<UsePanelCollapserProps, 'onCloseFinish' | 'onCloseStart' | 'onOpenFinish' | 'onOpenStart'> &
   Partial<Pick<UsePanelCollapserProps, 'duration' | 'easing'>> &
   AccordionItemStateProps & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     orientation?: Orientation;
     parentRef: React.Ref<HTMLDivElement>;

--- a/src/compositions/Accordion/AccordionLabel.tsx
+++ b/src/compositions/Accordion/AccordionLabel.tsx
@@ -7,7 +7,7 @@ import styles from './styles/AccordionLabel.module.css';
 import { AccordionItemStateProps } from './types';
 
 export type LocalAccordionLabelProps = AccordionItemStateProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   iconOnly?: boolean;
   id: string;

--- a/src/compositions/Accordion/types.ts
+++ b/src/compositions/Accordion/types.ts
@@ -7,9 +7,15 @@ export type AccordionItemStateProps = {
 };
 
 export type AccordionItemType = Omit<InteractiveGroupItemType<string>, 'label'> & {
-  content: React.ReactNode | ((props: AccordionItemStateProps) => React.ReactNode);
+  content:
+    | React.ReactChild
+    | React.ReactFragment
+    | ((props: AccordionItemStateProps) => React.ReactChild | React.ReactFragment);
   contentProps?: Record<string, unknown>;
   iconOnly?: boolean;
-  label: React.ReactNode | ((props: AccordionItemStateProps) => React.ReactNode);
+  label:
+    | React.ReactChild
+    | React.ReactFragment
+    | ((props: AccordionItemStateProps) => React.ReactChild | React.ReactFragment);
   labelProps?: Record<string, unknown>;
 };

--- a/src/compositions/Banner/Banner.tsx
+++ b/src/compositions/Banner/Banner.tsx
@@ -23,7 +23,7 @@ export const bannerTranslations: BannerTranslations = {
 export interface BannerProps
   extends Omit<PaperProps, 'bordered' | 'children' | 'color' | 'contained' | 'container' | 'flexible' | 'full'>,
     Omit<ThemeProps, 'contrast' | 'unthemed'> {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   /** The context ID is used by the banner system */
   contextId?: string;

--- a/src/compositions/Banner/BannerContainer.tsx
+++ b/src/compositions/Banner/BannerContainer.tsx
@@ -6,7 +6,7 @@ import styles from './styles/Banner.module.css';
 
 export type BannerContainerProps = React.HTMLAttributes<HTMLDivElement> &
   Omit<ThemeProps, 'contrast' | 'unthemed'> & {
-    children: React.ReactNode;
+    children?: React.ReactChild | React.ReactFragment;
     className?: string;
     style?: React.CSSProperties;
   };

--- a/src/compositions/Banner/Banners.tsx
+++ b/src/compositions/Banner/Banners.tsx
@@ -3,7 +3,7 @@ import { BannerProvider } from './BannerProvider';
 import { BannersFromContext, BannersFromContextProps } from './BannersFromContext';
 
 export type BannersProps = BannersFromContextProps & {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
 };
 
 /**

--- a/src/compositions/Chip/ChipContent.tsx
+++ b/src/compositions/Chip/ChipContent.tsx
@@ -6,8 +6,8 @@ import { ChipSize } from './types';
 
 export type ChipContentProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> & {
   avatar: Omit<AvatarProps, 'actionable' | 'className'>;
-  icon?: React.ReactNode;
-  text: React.ReactNode;
+  icon?: React.ReactChild | React.ReactFragment | null;
+  text: React.ReactChild | React.ReactFragment;
   size?: ChipSize;
   style?: React.CSSProperties;
 };

--- a/src/compositions/Dropdown/DropdownWithTags.tsx
+++ b/src/compositions/Dropdown/DropdownWithTags.tsx
@@ -170,41 +170,47 @@ export function DropdownWithTags({
         <TagGroup size={tagSize} {...tagGroupProps}>
           {options
             .filter(({ id }) => state.selectedIds.includes(id))
-            .map(({ id: itemId, label, ...tagItemProps }, i) => (
-              <Tag<'button'>
-                actionable
-                as="button"
-                contrast={contrast}
-                key={`${generateComponentId(id, itemId)}_tag`}
-                onClick={() => removeItem(itemId)}
-                ref={i === 0 ? tagRef : undefined}
-                shape={tagShape}
-                size={tagSize}
-                themeId={themeId}
-                weight={tagWeight}
-                {...tagProps}
-                {...mappedProps[itemId]}
-              >
-                {tag ? (
-                  renderFromProp<DropdownWithTagsOption>(tag, {
-                    id: itemId,
-                    label,
-                    themeId,
-                    ...tagItemProps,
-                  })
-                ) : (
-                  <IconText
-                    reverse
-                    icon={
-                      <TypographyWithSvg<'div'> as="div" volume="quiet">
-                        <TimesIcon scale="xsmall" />
-                      </TypographyWithSvg>
-                    }
-                    text={<Rhythm mr={2}>{label}</Rhythm>}
-                  />
-                )}
-              </Tag>
-            ))}
+            .map(({ id: itemId, label, ...tagItemProps }, i) => {
+              const children = tag ? (
+                renderFromProp<DropdownWithTagsOption>(tag, {
+                  id: itemId,
+                  label,
+                  themeId,
+                  ...tagItemProps,
+                })
+              ) : (
+                <IconText
+                  reverse
+                  icon={
+                    <TypographyWithSvg<'div'> as="div" volume="quiet">
+                      <TimesIcon scale="xsmall" />
+                    </TypographyWithSvg>
+                  }
+                  text={<Rhythm mr={2}>{label}</Rhythm>}
+                />
+              );
+
+              return (
+                children && (
+                  <Tag<'button'>
+                    actionable
+                    as="button"
+                    contrast={contrast}
+                    key={`${generateComponentId(id, itemId)}_tag`}
+                    onClick={() => removeItem(itemId)}
+                    ref={i === 0 ? tagRef : undefined}
+                    shape={tagShape}
+                    size={tagSize}
+                    themeId={themeId}
+                    weight={tagWeight}
+                    {...tagProps}
+                    {...mappedProps[itemId]}
+                  >
+                    {children}
+                  </Tag>
+                )
+              );
+            })}
         </TagGroup>
       </Rhythm>
     </Flex>

--- a/src/compositions/Dropover/DropoverInputLabel.tsx
+++ b/src/compositions/Dropover/DropoverInputLabel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './styles/Dropover.module.css';
 
 export type DropoverInputLabelProps = {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   cloned?: boolean;
   focused?: boolean;

--- a/src/compositions/Dropover/DropoverLabel.tsx
+++ b/src/compositions/Dropover/DropoverLabel.tsx
@@ -9,7 +9,7 @@ import styles from './styles/Dropover.module.css';
 
 export type DropoverLabelProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     cloned?: boolean;
     focused?: boolean;

--- a/src/compositions/IconGroup/IconGroup.tsx
+++ b/src/compositions/IconGroup/IconGroup.tsx
@@ -6,7 +6,6 @@ import { Flex, FlexProps } from '../../components/Flex/Flex';
 export type IconGroupProps = MergeProps<
   FlexProps,
   {
-    children: React.ReactNode;
     className?: FlexProps['className'];
     scale?: ScaleProviderProps['scale'];
     size?: ScaleProviderProps['size'];

--- a/src/compositions/InteractiveList/InteractiveListItem.tsx
+++ b/src/compositions/InteractiveList/InteractiveListItem.tsx
@@ -11,7 +11,7 @@ type StateProps = {
 
 export type LocalInteractiveListItemProps = {
   id: string;
-  label: React.ReactNode | ((state: StateProps) => React.ReactNode);
+  label: React.ReactChild | React.ReactFragment | ((state: StateProps) => React.ReactChild | React.ReactFragment);
   mimicSelectOnFocus?: boolean;
   onClick: (event: React.MouseEvent | React.TouchEvent, id: LocalInteractiveListItemProps['id']) => void;
 };

--- a/src/compositions/InteractiveList/PartialInteractiveList.tsx
+++ b/src/compositions/InteractiveList/PartialInteractiveList.tsx
@@ -33,7 +33,7 @@ type ExplicitProviderProps = Pick<
 
 export type LocalPartialInteractiveListProps = ExplicitProviderProps & {
   /** The children element is shown when there are no list elements */
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   /** A superficial focus state can be set outside of this component so that focus styles can be applied when, for example, a parent is focused */
   focused?: boolean;
   listComponent?: typeof List;

--- a/src/compositions/Modal/ModalBody.tsx
+++ b/src/compositions/Modal/ModalBody.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './styles/Modal.module.css';
 
 export type ModalBodyProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   flush?: boolean;
   scrollable?: boolean;

--- a/src/compositions/Modal/ModalContainer.tsx
+++ b/src/compositions/Modal/ModalContainer.tsx
@@ -5,7 +5,7 @@ import { useHandleEscape, UseHandleEscapeProps } from '../../hooks/useHandleEsca
 import styles from './styles/ModalContainer.module.css';
 
 export type ModalContainerProps = {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   /** If this is provided it must return true in order for the modal to be closed */
   confirmClose?: UseHandleEscapeProps['confirm'];

--- a/src/compositions/Modal/ModalFooter.tsx
+++ b/src/compositions/Modal/ModalFooter.tsx
@@ -4,7 +4,7 @@ import styles from './styles/Modal.module.css';
 
 export type ModalFooterProps = React.HTMLAttributes<HTMLDivElement> & {
   bordered?: boolean;
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
 };
 

--- a/src/compositions/Modal/ModalHeader.tsx
+++ b/src/compositions/Modal/ModalHeader.tsx
@@ -7,7 +7,7 @@ import { useModalComponentIds } from './useModalComponentIds';
 export type ModalHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   align?: 'left' | 'center' | 'right';
   bordered?: boolean;
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   className?: string;
   modalId?: string;
   title?: string;

--- a/src/compositions/Modal/Modals.tsx
+++ b/src/compositions/Modal/Modals.tsx
@@ -3,7 +3,7 @@ import { ModalProvider } from './ModalProvider';
 import { ModalsFromContext, ModalsFromContextProps } from './ModalsFromContext';
 
 export type ModalsProps = ModalsFromContextProps & {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
 };
 
 /**

--- a/src/compositions/Navigation/InnerNavigation.tsx
+++ b/src/compositions/Navigation/InnerNavigation.tsx
@@ -33,7 +33,10 @@ export type InnerNavigationProps = React.HTMLAttributes<NavigationElementType> &
     /** The triggerOnly prop can be ignored as it is handled by the interactive group system */
     items: ReadonlyArray<
       Omit<NavigationItemProps, 'children' | 'componentId' | 'key' | 'onClick' | 'orientation' | 'variant'> & {
-        label: React.ReactNode | ((props: NavigationItemStateProps) => React.ReactNode);
+        label:
+          | React.ReactChild
+          | React.ReactFragment
+          | ((props: NavigationItemStateProps) => React.ReactChild | React.ReactFragment);
         triggerOnly?: InteractiveGroupItemType<string>['triggerOnly'];
       }
     >;

--- a/src/compositions/Navigation/NavigationItem.tsx
+++ b/src/compositions/Navigation/NavigationItem.tsx
@@ -14,7 +14,10 @@ export type NavigationItemStateProps = {
 
 export type LocalNavigationItemProps = NavigationItemStateProps & {
   allowRightClickLinks?: boolean;
-  children: React.ReactNode | ((props: NavigationItemStateProps) => React.ReactNode);
+  children:
+    | React.ReactChild
+    | React.ReactFragment
+    | ((props: NavigationItemStateProps) => React.ReactChild | React.ReactFragment);
   className?: string;
   componentId?: string;
   flush?: boolean;

--- a/src/compositions/Popover/InlinePopover.tsx
+++ b/src/compositions/Popover/InlinePopover.tsx
@@ -76,6 +76,22 @@ export function InlinePopover<F extends HTMLElement | undefined = undefined>({
       permanent={permanent}
       position={position}
       renderContent={({ close, focusRef, isTogglerFocused, offset, position, visible, ...contentProps }) => {
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
+              renderChildren!,
+              {
+                close,
+                focusRef,
+                isTogglerFocused,
+                offset,
+                position,
+                visible,
+              },
+            )
+          : children;
+
+        if (!content) throw new Error('Missing popover content');
+
         return (
           <InlinePopoverContent<F>
             className={contentClassName}
@@ -87,19 +103,7 @@ export function InlinePopover<F extends HTMLElement | undefined = undefined>({
             {...contentProps}
             {...props}
           >
-            {renderChildren
-              ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
-                  renderChildren!,
-                  {
-                    close,
-                    focusRef,
-                    isTogglerFocused,
-                    offset,
-                    position,
-                    visible,
-                  },
-                )
-              : children}
+            {content}
           </InlinePopoverContent>
         );
       }}

--- a/src/compositions/Popover/PortalPopover.tsx
+++ b/src/compositions/Popover/PortalPopover.tsx
@@ -74,6 +74,22 @@ export function PortalPopover<F extends HTMLElement | undefined = undefined>({
       permanent={permanent}
       position={position}
       renderContent={({ close, focusable, focusRef, isTogglerFocused, offset, position, visible, ...contentProps }) => {
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<PortalPopoverContentHTMLElement, F>>(
+              renderChildren!,
+              {
+                close,
+                focusRef,
+                offset,
+                position,
+                isTogglerFocused,
+                visible,
+              },
+            )
+          : children;
+
+        if (!content) throw new Error('Missing popover content');
+
         return (
           <Portal
             className={contentClassName}
@@ -85,19 +101,7 @@ export function PortalPopover<F extends HTMLElement | undefined = undefined>({
             {...contentProps}
             {...props}
           >
-            {renderChildren
-              ? renderFromPropWithFallback<PopoverRenderChildrenProps<PortalPopoverContentHTMLElement, F>>(
-                  renderChildren!,
-                  {
-                    close,
-                    focusRef,
-                    offset,
-                    position,
-                    isTogglerFocused,
-                    visible,
-                  },
-                )
-              : children}
+            {content}
           </Portal>
         );
       }}

--- a/src/compositions/Popover/stories/InlinePopover.stories.tsx
+++ b/src/compositions/Popover/stories/InlinePopover.stories.tsx
@@ -9,8 +9,12 @@ import { Rhythm } from 'components/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
 import { InlinePopover, InlinePopoverProps } from '../InlinePopover';
-import { defaultOffset } from '../Popover';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
+
+const defaultOffset = {
+  horizontal: 0,
+  vertical: 0,
+};
 
 export default {
   title: 'Surfaces/Popover/InlinePopover',
@@ -171,18 +175,24 @@ export default {
     },
   },
   decorators: [
-    (Story, { args: { position } }) => (
+    (Story, { args: { layout, position } }) => (
       <div
         style={{
-          display: 'flex',
           margin: 20,
           width: 380,
-          height: 140,
-          justifyContent: justifyContentByPosition(position),
-          alignItems: alignItemsByPosition(position),
+          height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 90 : 140,
+          position: 'relative',
         }}
       >
-        {Story()}
+        <div
+          style={{
+            position: 'absolute',
+            ...getHorizontalPosition(position, layout),
+            ...getVerticalPosition(position, layout),
+          }}
+        >
+          {Story()}
+        </div>
       </div>
     ),
   ],
@@ -304,6 +314,7 @@ export const LeftTopPosition = Template.bind({});
 LeftTopPosition.storyName = 'Position: Left top';
 LeftTopPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'left-top',
 };
@@ -312,6 +323,7 @@ export const LeftCenterPosition = Template.bind({});
 LeftCenterPosition.storyName = 'Position: Left center';
 LeftCenterPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'left-center',
 };
@@ -320,6 +332,7 @@ export const LeftBottomPosition = Template.bind({});
 LeftBottomPosition.storyName = 'Position: Left bottom';
 LeftBottomPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'left-bottom',
 };
@@ -328,6 +341,7 @@ export const RightTopPosition = Template.bind({});
 RightTopPosition.storyName = 'Position: Right top';
 RightTopPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'right-top',
 };
@@ -336,6 +350,7 @@ export const RightCenterPosition = Template.bind({});
 RightCenterPosition.storyName = 'Position: Right center';
 RightCenterPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'right-center',
 };
@@ -344,8 +359,25 @@ export const RightBottomPosition = Template.bind({});
 RightBottomPosition.storyName = 'Position: Right bottom';
 RightBottomPosition.args = {
   ...defaultArgs,
+  layout: 'horizontal',
   offset: { horizontal: 8 },
   position: 'right-bottom',
+};
+
+export const VerticalLayout = Template.bind({});
+VerticalLayout.storyName = 'Layout: Vertical';
+VerticalLayout.args = {
+  ...defaultArgs,
+  offset: { vertical: 8 },
+  layout: 'vertical',
+};
+
+export const HorizontalLayout = Template.bind({});
+HorizontalLayout.storyName = 'Layout: Horizontal';
+HorizontalLayout.args = {
+  ...defaultArgs,
+  layout: 'horizontal',
+  offset: { horizontal: 8 },
 };
 
 export const ManualFocus = Template.bind({});

--- a/src/compositions/Popover/stories/PortalPopover.stories.tsx
+++ b/src/compositions/Popover/stories/PortalPopover.stories.tsx
@@ -8,9 +8,13 @@ import { Paper } from 'components/Paper';
 import { Rhythm } from 'components/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
-import { defaultOffset } from '../Popover';
 import { PortalPopover, PortalPopoverProps } from '../PortalPopover';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
+
+const defaultOffset = {
+  horizontal: 0,
+  vertical: 0,
+};
 
 export default {
   title: 'Surfaces/Popover/PortalPopover',
@@ -181,18 +185,24 @@ export default {
     },
   },
   decorators: [
-    (Story, { args: { position } }) => (
+    (Story, { args: { layout, position } }) => (
       <div
         style={{
-          display: 'flex',
           margin: 20,
           width: 380,
-          height: 140,
-          justifyContent: justifyContentByPosition(position),
-          alignItems: alignItemsByPosition(position),
+          height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 90 : 140,
+          position: 'relative',
         }}
       >
-        {Story()}
+        <div
+          style={{
+            position: 'absolute',
+            ...getHorizontalPosition(position, layout),
+            ...getVerticalPosition(position, layout),
+          }}
+        >
+          {Story()}
+        </div>
       </div>
     ),
   ],
@@ -357,6 +367,22 @@ RightBottomPosition.args = {
   ...defaultArgs,
   offset: { horizontal: 8 },
   position: 'right-bottom',
+};
+
+export const VerticalLayout = Template.bind({});
+VerticalLayout.storyName = 'Layout: Vertical';
+VerticalLayout.args = {
+  ...defaultArgs,
+  offset: { vertical: 8 },
+  layout: 'vertical',
+};
+
+export const HorizontalLayout = Template.bind({});
+HorizontalLayout.storyName = 'Layout: Horizontal';
+HorizontalLayout.args = {
+  ...defaultArgs,
+  offset: { horizontal: 8 },
+  layout: 'horizontal',
 };
 
 export const AbsolutePortal = Template.bind({});

--- a/src/compositions/Popover/stories/helpers/position.ts
+++ b/src/compositions/Popover/stories/helpers/position.ts
@@ -1,41 +1,56 @@
-import { StackedPosition, AnyPosition } from 'types/ui';
+import { Orientation, StackedPosition, AnyPosition } from 'types/ui';
 
-export const justifyContentByPosition = (position?: AnyPosition | StackedPosition) => {
-  if (!position) return undefined;
+export const getHorizontalPosition = (position?: AnyPosition | StackedPosition, layout?: Orientation) => {
+  if (position) {
+    if (
+      (
+        ['top-left', 'bottom-left', 'left-top', 'left-center', 'left-bottom'] as Array<AnyPosition | StackedPosition>
+      ).includes(position)
+    ) {
+      return { right: 0 };
+    }
 
-  if (
-    (
-      ['top-left', 'bottom-left', 'left-top', 'left-center', 'left-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-end';
+    if (
+      (
+        ['top-right', 'bottom-right', 'right-top', 'right-center', 'right-bottom'] as Array<
+          AnyPosition | StackedPosition
+        >
+      ).includes(position)
+    ) {
+      return { left: 0 };
+    }
+  } else {
+    if (layout === 'horizontal') {
+      return { left: 0 };
+    }
   }
-  if (
-    (
-      ['top-right', 'bottom-right', 'right-top', 'right-center', 'right-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-start';
-  }
-  return 'center';
+
+  return { left: '50%', transform: 'translateX(-50%)' };
 };
 
-export const alignItemsByPosition = (position?: AnyPosition | StackedPosition) => {
-  if (!position) return undefined;
+export const getVerticalPosition = (position?: AnyPosition | StackedPosition, layout?: Orientation) => {
+  if (position) {
+    if (
+      (
+        ['top-left', 'top-center', 'top-right', 'left-bottom', 'right-bottom'] as Array<AnyPosition | StackedPosition>
+      ).includes(position)
+    ) {
+      return { bottom: 0 };
+    }
+    if (
+      (
+        ['bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'right-top'] as Array<
+          AnyPosition | StackedPosition
+        >
+      ).includes(position)
+    ) {
+      return { top: 0 };
+    }
+  } else {
+    if (layout === 'vertical') {
+      return { bottom: 0 };
+    }
+  }
 
-  if (
-    (
-      ['top-left', 'top-center', 'top-right', 'left-bottom', 'right-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-end';
-  }
-  if (
-    (
-      ['bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'right-top'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-start';
-  }
-  return 'center';
+  return { top: '50%', transform: 'translateY(-50%)' };
 };

--- a/src/compositions/Popover/types.ts
+++ b/src/compositions/Popover/types.ts
@@ -41,7 +41,7 @@ export type PopoverContentPropsRenderChildren<C extends HTMLElement, F extends H
 
 export type PopoverContentPropsChildren = {
   /** If there are children then `renderChildren` is ignored */
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   renderChildren?: never;
 };
 

--- a/src/compositions/StatusBubble/StatusBubble.tsx
+++ b/src/compositions/StatusBubble/StatusBubble.tsx
@@ -17,9 +17,9 @@ const defaultOffset = {
 export type StatusBubbleProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> &
   Omit<ThemeProps, 'contrast'> & {
     anchor: React.ReactElement;
-    children?: React.ReactNode;
+    children?: React.ReactChild | React.ReactFragment | null;
     color?: SemanticColor;
-    header?: React.ReactNode;
+    header?: React.ReactChild | React.ReactFragment | null;
     offset?: Offset;
     position?: HorizontalPositionCentered | HorizontalPositionEdge;
     /** Remove the border radius */

--- a/src/compositions/Tabs/Tab.tsx
+++ b/src/compositions/Tabs/Tab.tsx
@@ -13,7 +13,7 @@ export type TabStateProps = {
 };
 
 export type LocalTabProps = TabStateProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   /** This is used to match the aria labels up with the tabs */
   componentId?: string;

--- a/src/compositions/Tabs/TabList.tsx
+++ b/src/compositions/Tabs/TabList.tsx
@@ -16,7 +16,7 @@ import { TabsVariant } from './types';
 
 export type TabListItemProps = Pick<TabProps, 'disabled' | 'iconOnly'> & {
   id: string;
-  label: React.ReactNode | ((props: TabStateProps) => React.ReactNode);
+  label: React.ReactChild | React.ReactFragment | ((props: TabStateProps) => React.ReactChild | React.ReactFragment);
   labelProps?: Omit<
     TabProps,
     'children' | 'disabled' | 'focused' | 'iconOnly' | 'id' | 'onClick' | 'orientation' | 'selected' | 'unstyled'

--- a/src/compositions/Tabs/TabPanel.tsx
+++ b/src/compositions/Tabs/TabPanel.tsx
@@ -8,7 +8,7 @@ export type TabPanelStateProps = {
 };
 
 export type TabPanelProps = TabPanelStateProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   /** Remove the padding from the tab panel */
   flush?: boolean;
   id: string;

--- a/src/compositions/Tabs/TabPanelGroup.tsx
+++ b/src/compositions/Tabs/TabPanelGroup.tsx
@@ -20,7 +20,10 @@ export type TabPanelGroupProps = React.HTMLAttributes<HTMLDivElement> &
     focused?: boolean;
     items: ReadonlyArray<{
       id: string;
-      content: React.ReactNode | ((props: TabPanelStateProps) => React.ReactNode);
+      content:
+        | React.ReactChild
+        | React.ReactFragment
+        | ((props: TabPanelStateProps) => React.ReactChild | React.ReactFragment);
       contentProps?: Omit<TabPanelProps, 'children' | 'id' | 'selected'>;
     }>;
     orientation?: Orientation;

--- a/src/compositions/Tabs/TabsContainer.tsx
+++ b/src/compositions/Tabs/TabsContainer.tsx
@@ -8,7 +8,7 @@ import { TabsVariant } from './types';
 
 export type TabsContainerProps = React.HTMLAttributes<HTMLDivElement> &
   ThemeProps & {
-    children: React.ReactNode;
+    children: React.ReactChild | React.ReactFragment;
     className?: string;
     focused?: boolean;
     orientation?: Orientation;

--- a/src/compositions/TextboxGroup/TextboxGroupContainer.tsx
+++ b/src/compositions/TextboxGroup/TextboxGroupContainer.tsx
@@ -3,7 +3,7 @@ import { ThemeProps } from '../../types';
 import { ListRegistryProvider } from '../../components/ListRegistry/ListRegistryProvider';
 
 export type TextboxGroupContainerProps = ThemeProps & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
 };
 
 /**

--- a/src/compositions/Toast/TitledToast.tsx
+++ b/src/compositions/Toast/TitledToast.tsx
@@ -5,7 +5,7 @@ import { Toast, ToastProps } from './Toast';
 import { useToastComponentIds } from './useToastComponentIds';
 
 export type TitledToastProps = Omit<ToastProps, 'title'> & {
-  title: React.ReactNode;
+  title: React.ReactChild | React.ReactFragment;
 };
 
 /**

--- a/src/compositions/Toast/Toast.tsx
+++ b/src/compositions/Toast/Toast.tsx
@@ -25,7 +25,7 @@ export const toastTranslations: ToastTranslations = {
 };
 
 export type LocalToastProps = Omit<ThemeProps, 'contrast'> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   className?: string;
   /** The context ID is used by both the toast system and the aria-label system */
   contextId?: string;

--- a/src/compositions/Tooltip/InlineTextTooltip.tsx
+++ b/src/compositions/Tooltip/InlineTextTooltip.tsx
@@ -63,6 +63,7 @@ export function InlineTextTooltip<F extends HTMLElement | undefined = undefined>
     <InlinePopover<F>
       isTooltip
       centered={!uncentered}
+      layout={layout}
       offset={offset}
       position={position}
       renderChildren={({ close, focusRef, isTogglerFocused, offset, position, visible }) => {

--- a/src/compositions/Tooltip/InlineTextTooltip.tsx
+++ b/src/compositions/Tooltip/InlineTextTooltip.tsx
@@ -70,6 +70,22 @@ export function InlineTextTooltip<F extends HTMLElement | undefined = undefined>
           throw new Error('Invalid tooltip position');
         }
 
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
+              renderChildren!,
+              {
+                close,
+                focusRef,
+                isTogglerFocused,
+                offset,
+                position,
+                visible,
+              },
+            )
+          : children;
+
+        if (!content) throw new Error('Missing tooltip content');
+
         return (
           <TooltipContent
             className={tooltipClassName}
@@ -89,19 +105,7 @@ export function InlineTextTooltip<F extends HTMLElement | undefined = undefined>
               themeId={themeId}
               width={width}
             >
-              {renderChildren
-                ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
-                    renderChildren!,
-                    {
-                      close,
-                      focusRef,
-                      isTogglerFocused,
-                      offset,
-                      position,
-                      visible,
-                    },
-                  )
-                : children}
+              {content}
             </TextTooltipContent>
           </TooltipContent>
         );

--- a/src/compositions/Tooltip/InlineTooltip.tsx
+++ b/src/compositions/Tooltip/InlineTooltip.tsx
@@ -52,6 +52,7 @@ export function InlineTooltip<F extends HTMLElement | undefined = undefined>({
     <InlinePopover<F>
       isTooltip
       centered={!uncentered}
+      layout={layout}
       offset={offset}
       position={position}
       renderChildren={({ close, focusRef, isTogglerFocused, offset, position, visible }) => {

--- a/src/compositions/Tooltip/InlineTooltip.tsx
+++ b/src/compositions/Tooltip/InlineTooltip.tsx
@@ -59,6 +59,22 @@ export function InlineTooltip<F extends HTMLElement | undefined = undefined>({
           throw new Error('Invalid tooltip position');
         }
 
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
+              renderChildren!,
+              {
+                close,
+                focusRef,
+                isTogglerFocused,
+                offset,
+                position,
+                visible,
+              },
+            )
+          : children;
+
+        if (!content) throw new Error('Missing tooltip content');
+
         return (
           <TooltipContent
             className={tooltipClassName}
@@ -71,19 +87,7 @@ export function InlineTooltip<F extends HTMLElement | undefined = undefined>({
             triangleColor={triangleColor}
             triangleSize={triangleSize}
           >
-            {renderChildren
-              ? renderFromPropWithFallback<PopoverRenderChildrenProps<InlinePopoverContentHTMLElement, F>>(
-                  renderChildren!,
-                  {
-                    close,
-                    focusRef,
-                    isTogglerFocused,
-                    offset,
-                    position,
-                    visible,
-                  },
-                )
-              : children}
+            {content}
           </TooltipContent>
         );
       }}

--- a/src/compositions/Tooltip/PortalTextTooltip.tsx
+++ b/src/compositions/Tooltip/PortalTextTooltip.tsx
@@ -70,6 +70,19 @@ export function PortalTextTooltip<F extends HTMLElement | undefined = undefined>
           throw new Error('Invalid tooltip position');
         }
 
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<HTMLDivElement, F>>(renderChildren!, {
+              close,
+              focusRef,
+              isTogglerFocused,
+              offset,
+              position,
+              visible,
+            })
+          : children;
+
+        if (!content) throw new Error('Missing tooltip content');
+
         return (
           <TooltipContent
             className={tooltipClassName}
@@ -89,16 +102,7 @@ export function PortalTextTooltip<F extends HTMLElement | undefined = undefined>
               themeId={themeId}
               width={width}
             >
-              {renderChildren
-                ? renderFromPropWithFallback<PopoverRenderChildrenProps<HTMLDivElement, F>>(renderChildren!, {
-                    close,
-                    focusRef,
-                    isTogglerFocused,
-                    offset,
-                    position,
-                    visible,
-                  })
-                : children}
+              {content}
             </TextTooltipContent>
           </TooltipContent>
         );

--- a/src/compositions/Tooltip/PortalTextTooltip.tsx
+++ b/src/compositions/Tooltip/PortalTextTooltip.tsx
@@ -63,6 +63,7 @@ export function PortalTextTooltip<F extends HTMLElement | undefined = undefined>
     <PortalPopover<F>
       isTooltip
       centered={!uncentered}
+      layout={layout}
       offset={offset}
       position={position}
       renderChildren={({ close, focusRef, isTogglerFocused, offset, position, visible }) => {

--- a/src/compositions/Tooltip/PortalTooltip.tsx
+++ b/src/compositions/Tooltip/PortalTooltip.tsx
@@ -52,6 +52,7 @@ export function PortalTooltip<F extends HTMLElement | undefined = undefined>({
     <PortalPopover<F>
       isTooltip
       centered={!uncentered}
+      layout={layout}
       offset={offset}
       position={position}
       renderChildren={({ close, focusRef, isTogglerFocused, offset, position, visible }) => {

--- a/src/compositions/Tooltip/PortalTooltip.tsx
+++ b/src/compositions/Tooltip/PortalTooltip.tsx
@@ -59,6 +59,22 @@ export function PortalTooltip<F extends HTMLElement | undefined = undefined>({
           throw new Error('Invalid tooltip position');
         }
 
+        const content = renderChildren
+          ? renderFromPropWithFallback<PopoverRenderChildrenProps<PortalPopoverContentHTMLElement, F>>(
+              renderChildren!,
+              {
+                close,
+                focusRef,
+                isTogglerFocused,
+                offset,
+                position,
+                visible,
+              },
+            )
+          : children;
+
+        if (!content) throw new Error('Missing tooltip content');
+
         return (
           <TooltipContent
             className={tooltipClassName}
@@ -71,19 +87,7 @@ export function PortalTooltip<F extends HTMLElement | undefined = undefined>({
             triangleColor={triangleColor}
             triangleSize={triangleSize}
           >
-            {renderChildren
-              ? renderFromPropWithFallback<PopoverRenderChildrenProps<PortalPopoverContentHTMLElement, F>>(
-                  renderChildren!,
-                  {
-                    close,
-                    focusRef,
-                    isTogglerFocused,
-                    offset,
-                    position,
-                    visible,
-                  },
-                )
-              : children}
+            {content}
           </TooltipContent>
         );
       }}

--- a/src/compositions/Tooltip/TooltipContent.tsx
+++ b/src/compositions/Tooltip/TooltipContent.tsx
@@ -7,7 +7,7 @@ import { Triangle } from '../../components/Triangle/Triangle';
 import styles from './styles/TooltipContent.module.css';
 
 export type TooltipContentProps = React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   /** If the position is `[left|right]-[top|bottom]` then the triangle can be a corner triangle (eg. flat top or bottom) */
   cornerTriangle?: boolean;
   layout?: Orientation;

--- a/src/compositions/Tooltip/stories/InlineTextTooltip.stories.tsx
+++ b/src/compositions/Tooltip/stories/InlineTextTooltip.stories.tsx
@@ -8,7 +8,7 @@ import { Rhythm } from 'components/Rhythm/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
 import { InlineTextTooltip, InlineTextTooltipProps } from '../InlineTextTooltip';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
 
 export default {
   title: 'Surfaces/Tooltip/InlineTextTooltip',
@@ -253,17 +253,24 @@ Default.parameters = {
 };
 
 Default.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { layout, position } }) => (
     <div
       style={{
-        display: 'flex',
         margin: 20,
-        height: 140,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        width: 380,
+        height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 60 : 90,
+        position: 'relative',
       }}
     >
-      {Story()}
+      <div
+        style={{
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        {Story()}
+      </div>
     </div>
   ),
 ];
@@ -297,21 +304,25 @@ OnText.args = {
 };
 
 OnText.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { position, layout } }) => (
     <Typography<'div'>
       as="div"
       color="primary"
       style={{
-        display: 'flex',
         margin: 20,
         height: 180,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        position: 'relative',
       }}
     >
-      <span>Hello, world.</span>
-      {Story()}
-      <span>There are others like me as well.</span>
+      <div
+        style={{
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        {Story()}
+      </div>
     </Typography>
   ),
 ];
@@ -332,21 +343,29 @@ OnIcon.args = {
 };
 
 OnIcon.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { position, layout } }) => (
     <Typography<'div'>
       as="div"
       color="primary"
       style={{
-        display: 'flex',
         margin: 20,
         height: 60,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        position: 'relative',
       }}
     >
-      <span>Sometimes a tooltip should be clickable, or on an icon.</span>
-      {Story()}
-      <span>That is neat.</span>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        <span>Sometimes a tooltip should be clickable, or on an icon.</span>
+        {Story()}
+        <span>That is neat.</span>
+      </div>
     </Typography>
   ),
 ];

--- a/src/compositions/Tooltip/stories/InlineTooltip.stories.tsx
+++ b/src/compositions/Tooltip/stories/InlineTooltip.stories.tsx
@@ -10,7 +10,7 @@ import { Rhythm } from 'components/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
 import { InlineTooltip, InlineTooltipProps } from '../InlineTooltip';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
 
 export default {
   title: 'Surfaces/Tooltip/InlineTooltip',
@@ -196,18 +196,24 @@ export default {
     },
   },
   decorators: [
-    (Story, { args: { position } }) => (
+    (Story, { args: { layout, position } }) => (
       <div
         style={{
-          display: 'flex',
           margin: 20,
           width: 380,
-          height: 140,
-          justifyContent: justifyContentByPosition(position),
-          alignItems: alignItemsByPosition(position),
+          height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 90 : 140,
+          position: 'relative',
         }}
       >
-        {Story()}
+        <div
+          style={{
+            position: 'absolute',
+            ...getHorizontalPosition(position, layout),
+            ...getVerticalPosition(position, layout),
+          }}
+        >
+          {Story()}
+        </div>
       </div>
     ),
   ],
@@ -358,6 +364,20 @@ RightBottomPosition.storyName = 'Position: Right bottom';
 RightBottomPosition.args = {
   ...defaultArgs,
   position: 'right-bottom',
+};
+
+export const VerticalLayout = Template.bind({});
+VerticalLayout.storyName = 'Layout: Vertical';
+VerticalLayout.args = {
+  ...defaultArgs,
+  layout: 'vertical',
+};
+
+export const HorizontalLayout = Template.bind({});
+HorizontalLayout.storyName = 'Layout: Horizontal';
+HorizontalLayout.args = {
+  ...defaultArgs,
+  layout: 'horizontal',
 };
 
 export const CornerTriangle = Template.bind({});

--- a/src/compositions/Tooltip/stories/PortalTextTooltip.stories.tsx
+++ b/src/compositions/Tooltip/stories/PortalTextTooltip.stories.tsx
@@ -8,7 +8,7 @@ import { Rhythm } from 'components/Rhythm/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
 import { PortalTextTooltip, PortalTextTooltipProps } from '../PortalTextTooltip';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
 
 export default {
   title: 'Surfaces/Tooltip/PortalTextTooltip',
@@ -264,17 +264,24 @@ Default.parameters = {
 };
 
 Default.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { layout, position } }) => (
     <div
       style={{
-        display: 'flex',
         margin: 20,
-        height: 140,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        width: 380,
+        height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 60 : 90,
+        position: 'relative',
       }}
     >
-      {Story()}
+      <div
+        style={{
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        {Story()}
+      </div>
     </div>
   ),
 ];
@@ -308,21 +315,25 @@ OnText.args = {
 };
 
 OnText.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { position, layout } }) => (
     <Typography<'div'>
       as="div"
       color="primary"
       style={{
-        display: 'flex',
         margin: 20,
         height: 180,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        position: 'relative',
       }}
     >
-      <span>Hello, world.</span>
-      {Story()}
-      <span>There are others like me as well.</span>
+      <div
+        style={{
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        {Story()}
+      </div>
     </Typography>
   ),
 ];
@@ -343,21 +354,29 @@ OnIcon.args = {
 };
 
 OnIcon.decorators = [
-  (Story, { args: { position } }) => (
+  (Story, { args: { position, layout } }) => (
     <Typography<'div'>
       as="div"
       color="primary"
       style={{
-        display: 'flex',
         margin: 20,
         height: 60,
-        justifyContent: justifyContentByPosition(position),
-        alignItems: alignItemsByPosition(position),
+        position: 'relative',
       }}
     >
-      <span>Sometimes a tooltip should be clickable, or on an icon.</span>
-      {Story()}
-      <span>That is neat.</span>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          position: 'absolute',
+          ...getHorizontalPosition(position, layout),
+          ...getVerticalPosition(position, layout),
+        }}
+      >
+        <span>Sometimes a tooltip should be clickable, or on an icon.</span>
+        {Story()}
+        <span>That is neat.</span>
+      </div>
     </Typography>
   ),
 ];

--- a/src/compositions/Tooltip/stories/PortalTooltip.stories.tsx
+++ b/src/compositions/Tooltip/stories/PortalTooltip.stories.tsx
@@ -10,7 +10,7 @@ import { Rhythm } from 'components/Rhythm';
 import { Typography } from 'components/Typography';
 import { PageTitle } from 'stories/helpers/PageTitle';
 import { PortalTooltip, PortalTooltipProps } from '../PortalTooltip';
-import { justifyContentByPosition, alignItemsByPosition } from './helpers/position';
+import { getHorizontalPosition, getVerticalPosition } from './helpers/position';
 
 export default {
   title: 'Surfaces/Tooltip/PortalTooltip',
@@ -206,18 +206,24 @@ export default {
     },
   },
   decorators: [
-    (Story, { args: { position } }) => (
+    (Story, { args: { layout, position } }) => (
       <div
         style={{
-          display: 'flex',
           margin: 20,
           width: 380,
-          height: 140,
-          justifyContent: justifyContentByPosition(position),
-          alignItems: alignItemsByPosition(position),
+          height: layout === 'horizontal' || (position && /^(right|left)-/.test(position)) ? 90 : 140,
+          position: 'relative',
         }}
       >
-        {Story()}
+        <div
+          style={{
+            position: 'absolute',
+            ...getHorizontalPosition(position, layout),
+            ...getVerticalPosition(position, layout),
+          }}
+        >
+          {Story()}
+        </div>
       </div>
     ),
   ],
@@ -369,6 +375,20 @@ RightBottomPosition.storyName = 'Position: Right bottom';
 RightBottomPosition.args = {
   ...defaultArgs,
   position: 'right-bottom',
+};
+
+export const VerticalLayout = Template.bind({});
+VerticalLayout.storyName = 'Layout: Vertical';
+VerticalLayout.args = {
+  ...defaultArgs,
+  layout: 'vertical',
+};
+
+export const HorizontalLayout = Template.bind({});
+HorizontalLayout.storyName = 'Layout: Horizontal';
+HorizontalLayout.args = {
+  ...defaultArgs,
+  layout: 'horizontal',
 };
 
 export const CornerTriangle = Template.bind({});

--- a/src/compositions/Tooltip/stories/helpers/position.ts
+++ b/src/compositions/Tooltip/stories/helpers/position.ts
@@ -1,41 +1,56 @@
-import { StackedPosition, AnyPosition } from 'types/ui';
+import { Orientation, StackedPosition, AnyPosition } from 'types/ui';
 
-export const justifyContentByPosition = (position?: AnyPosition | StackedPosition) => {
-  if (!position) return undefined;
+export const getHorizontalPosition = (position?: AnyPosition | StackedPosition, layout?: Orientation) => {
+  if (position) {
+    if (
+      (
+        ['top-left', 'bottom-left', 'left-top', 'left-center', 'left-bottom'] as Array<AnyPosition | StackedPosition>
+      ).includes(position)
+    ) {
+      return { right: 0 };
+    }
 
-  if (
-    (
-      ['top-left', 'bottom-left', 'left-top', 'left-center', 'left-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-end';
+    if (
+      (
+        ['top-right', 'bottom-right', 'right-top', 'right-center', 'right-bottom'] as Array<
+          AnyPosition | StackedPosition
+        >
+      ).includes(position)
+    ) {
+      return { left: 0 };
+    }
+  } else {
+    if (layout === 'horizontal') {
+      return { left: 0 };
+    }
   }
-  if (
-    (
-      ['top-right', 'bottom-right', 'right-top', 'right-center', 'right-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-start';
-  }
-  return 'center';
+
+  return { left: '50%', transform: 'translateX(-50%)' };
 };
 
-export const alignItemsByPosition = (position?: AnyPosition | StackedPosition) => {
-  if (!position) return undefined;
+export const getVerticalPosition = (position?: AnyPosition | StackedPosition, layout?: Orientation) => {
+  if (position) {
+    if (
+      (
+        ['top-left', 'top-center', 'top-right', 'left-bottom', 'right-bottom'] as Array<AnyPosition | StackedPosition>
+      ).includes(position)
+    ) {
+      return { bottom: 0 };
+    }
+    if (
+      (
+        ['bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'right-top'] as Array<
+          AnyPosition | StackedPosition
+        >
+      ).includes(position)
+    ) {
+      return { top: 0 };
+    }
+  } else {
+    if (layout === 'vertical') {
+      return { bottom: 0 };
+    }
+  }
 
-  if (
-    (
-      ['top-left', 'top-center', 'top-right', 'left-bottom', 'right-bottom'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-end';
-  }
-  if (
-    (
-      ['bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'right-top'] as Array<AnyPosition | StackedPosition>
-    ).includes(position)
-  ) {
-    return 'flex-start';
-  }
-  return 'center';
+  return { top: '50%', transform: 'translateY(-50%)' };
 };

--- a/src/docs/helpers/ColorSwatchVector.tsx
+++ b/src/docs/helpers/ColorSwatchVector.tsx
@@ -101,11 +101,11 @@ export type Color = {
   contrast?: string;
   height?: string | number;
   width?: string | number;
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
 };
 
 export type ColorSwatchVectorProps = {
-  children?: React.ReactNode;
+  children?: React.ReactChild | React.ReactFragment | null;
   colors: readonly Color[];
   direction?: FlexProps['direction'];
   joined?: boolean;

--- a/src/docs/helpers/ThemeWrapper.tsx
+++ b/src/docs/helpers/ThemeWrapper.tsx
@@ -23,7 +23,7 @@ type ThemeWrapperPropsWithThemeId = {
 };
 
 type ThemeWrapperPropsWithChildren = {
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactFragment;
   withThemeId?: false;
 };
 

--- a/src/hooks/usePopoverPosition.ts
+++ b/src/hooks/usePopoverPosition.ts
@@ -64,6 +64,8 @@ export const usePopoverPosition = (
         }
 
         setPosition([primary, secondary].join('-') as AnyPosition);
+      } else {
+        setPosition(layout === 'horizontal' ? 'right-center' : 'top-center');
       }
     };
 


### PR DESCRIPTION
Removed the more permissive `React.ReactNode` in favor of `React.ReactChild | React.ReactFragment`.